### PR TITLE
fixed warning C5208: unnamed class used in typedef name cannot declar…

### DIFF
--- a/dag_vecMathDecl.h
+++ b/dag_vecMathDecl.h
@@ -100,7 +100,7 @@ typedef const struct bsph3f& bsph3f_cref;
 
   typedef const vec4f vec4f_const;
 
-  typedef const union alignas(16)
+  typedef const union alignas(16) vec4i_const_name
   {
     unsigned m128_u32[4];
     vec4i m128;


### PR DESCRIPTION
unnamed class used in typedef name cannot declare members other than non-static data members, member enumerations, or member classes
fix gives it a name