### PR TITLE
Update from internal repository

### DIFF
--- a/dag_vecMath.h
+++ b/dag_vecMath.h
@@ -73,6 +73,9 @@ VECMATH_FINLINE vec4i VECTORCALL v_seti_x(int a);
 VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f(float x, float y, float z, float w);
 VECMATH_FINLINE vec4i VECTORCALL v_make_vec4i(int x, int y, int z, int w);
 
+//! unpack 4 low bits from bitmask to 4x32 bits mask, true=0xFFFFFFFF, false=0
+VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f_mask(uint8_t bitmask);
+
 //! store vector to  16-byte aligned memory
 VECMATH_FINLINE void VECTORCALL v_st(void *m, vec4f v);
 //! store vector to unaligned memory
@@ -97,6 +100,8 @@ VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a);
 
 //! component-wise comparison: for C={xyzw}  .C = a.C==b.C ? 0xFFFFFFFF : 0
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b);
+//! component-wise comparison: for C={xyzw}  .C = a.C!=b.C ? 0xFFFFFFFF : 0
+VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b);
 //! component-wise integer comparison: for C={xyzw}  .C = a.C==b.C ? 0xFFFFFFFF : 0
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b);
 VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b);
@@ -116,9 +121,12 @@ VECMATH_FINLINE vec4i VECTORCALL v_andnoti(vec4i a, vec4i b);
 VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b);
 //! a ^ b
 VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b);
-//! bit-wise select: for N={0..127}  .bitN = (c.bitN == 0) ? a.bitN : b.bitN
+//! component-wise select: for C={xyzw}  .C = c.C>=0 ? a.C : b.C
 VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c);
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c);
+VECMATH_FINLINE vec4f VECTORCALL v_seli(vec4f a, vec4f b, vec4f c);
+//! bit-wise select: for N={0..127}  .bitN = (c.bitN == 0) ? a.bitN : b.bitN
+VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c);
+VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c);
 
 //! convert to integer using cast
 VECMATH_FINLINE vec4i VECTORCALL v_cast_vec4i(vec4f a);
@@ -179,6 +187,8 @@ VECMATH_FINLINE vec4f VECTORCALL v_div(vec4f a, vec4f b);
 VECMATH_FINLINE vec4f VECTORCALL v_mod(vec4f a, vec4f b);
 //! (a * b + c)
 VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c);
+//! (a * b - c)
+VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c);
 //! -(a * b - c) == c - a*b
 VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c);
 //! .x = (a.x + b.x)
@@ -191,6 +201,8 @@ VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b);
 VECMATH_FINLINE vec4f VECTORCALL v_div_x(vec4f a, vec4f b);
 //! .x = (a.x * b.x + c.x)
 VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c);
+//! .x = (a.x * b.x - c.x)
+VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c);
 //! 1/a, fast estimate
 VECMATH_FINLINE vec4f VECTORCALL v_rcp_est(vec4f a);
 //! 1/a
@@ -405,6 +417,8 @@ VECMATH_FINLINE vec4f VECTORCALL v_norm4(vec4f a);
 VECMATH_FINLINE vec3f VECTORCALL v_norm3(vec3f a);
 //! nans converted to zero, v_and(a, v_cmp_eq(a,a))
 VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a);
+//! nans and infs converted to zero
+VECMATH_FINLINE vec4f VECTORCALL v_remove_not_finite(vec4f a);
 //! safe normalize: a/length(a)
 //! result is not guaranteed to be normalized, but is definetly not NaN (NAN components will be zero)
 VECMATH_FINLINE vec4f VECTORCALL v_norm4_safe(vec4f a);
@@ -571,6 +585,9 @@ VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, co
 //! mat44f from unaligned TMatrix
 VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43);
 
+//! mat44f from unaligned TMatrix but don't set row3 to {0,0,0,1} (will be undefined)
+VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43);
+
 //! mat44f from memaligned TMatrix
 VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43);
 
@@ -595,6 +612,8 @@ VECMATH_FINLINE void VECTORCALL v_bbox3_add_transformed_box(bbox3f &b, mat44f_cr
 
 //! .xyz = bbox dimensions; for empty bbox dimensions will be invalid (negative)
 VECMATH_FINLINE vec3f VECTORCALL v_bbox3_size(bbox3f_cref b);
+//! scale bbox by size_factor
+VECMATH_FINLINE bbox3f v_bbox3_scale(bbox3f_cref b, vec4f size_factor);
 //! .xyz = bbox center
 VECMATH_FINLINE vec3f VECTORCALL v_bbox3_center(bbox3f_cref b);
 //! .x = radius of outer sphere
@@ -603,6 +622,8 @@ VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad(bbox3f_cref b);
 //! .x = radius of inner sphere
 VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(vec3f bmin, vec3f bmax);
 VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(bbox3f_cref b);
+//! .x = diameter of inner sphere
+VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_diameter(vec3f bmin, vec3f bmax);
 
 //! returns point (0,0,0), b.bmin
 VECMATH_FINLINE vec4f VECTORCALL v_bbox3_pt000(bbox3f_cref b);
@@ -642,6 +663,14 @@ VECMATH_FINLINE int VECTORCALL v_bbox3_test_box_intersect_b(bbox3f_cref b1, bbox
 
 //! tests whether boxes intersect and returns boolean (0 or non-0). safe for above case
 VECMATH_FINLINE int VECTORCALL v_bbox3_test_box_intersect_b_safe(bbox3f_cref b1, bbox3f_cref b2);
+
+//! tests OBB box1 edges intersect planes of AABB box0 and returns boolean (0 or non-0).
+inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, bbox3f box1, const mat44f& tm1);
+
+//! tests whether OBB box0 and OBB box1 intersect and returns boolean (0 or non-0).
+VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1);
+VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
+                                                                        vec4f size_factor);
 
 //! tests whether box intersecs sphere and returns boolean
 VECMATH_FINLINE int VECTORCALL v_bbox3_test_sph_intersect(bbox3f_cref box, vec4f bsph_r2);
@@ -710,17 +739,20 @@ v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4
 ///universal visibility function (accepts worldviewproj matrix)
 ///return zero if not visible. nonzero, otherwise
 ///it is slower than v_is_visible_b_fast, so do not call it if you don't know what are you doing
-///for branching: (~v_test_vec_x_eq_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
+///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
 ///or use v_is_visible_b (it is faster on SSE)
 VECMATH_FINLINE vec4f VECTORCALL v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 
-///for branching: (~v_test_vec_x_eq_0( v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
+///for branching: (~v_test_vec_x_eqi_0( v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
 VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 //! gets perfect triangle bounding sphere center.
 // Warning - can work incorrectly on degenerative triangles (can produce nans)
 VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& p1, const vec3f& p2, const vec3f& p3 );
+
+// check is point p inside triangle with vertices t1,t2,t3 in 2D space
+VECMATH_INLINE bool VECTORCALL v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3);
 
 //
 // Quaternion math
@@ -800,9 +832,6 @@ VECMATH_FINLINE vec4f VECTORCALL v_pow_est(vec4f x, vec4f y);////exp_polynom_of_
 // vector -> scalar transformation (often incurs penalty!)
 //
 
-//! extracts fp32 component of float[4] by index
-VECMATH_FINLINE float VECTORCALL v_extract(vec4f v, int i);
-VECMATH_FINLINE int VECTORCALL v_extracti(vec4i v, int i);
 //! extracts fp32 x-component of float[4]
 VECMATH_FINLINE float VECTORCALL v_extract_x(vec4f v);
 //! extracts fp32 y-component of float[4]
@@ -840,6 +869,10 @@ VECMATH_FINLINE vec4f VECTORCALL v_promote(float s, int i);
 //
 // support for slow but sometimes necessary branching
 //
+//! (int(v.x) == int(a.x)) ? 1 : 0
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a);
+//! (int(v.x) == 0) ? 1 : 0
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v);
 
 //! (v.x == a.x) ? 1 : 0
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a);

--- a/dag_vecMathDecl.h
+++ b/dag_vecMathDecl.h
@@ -93,6 +93,9 @@ typedef const struct bsph3f& bsph3f_cref;
 
 #if _TARGET_SIMD_SSE
   #include <emmintrin.h>
+#ifdef _MSC_VER
+  #include <intrin.h>
+#endif
 
   typedef __m128 vec4f;
   typedef __m128 vec3f;

--- a/dag_vecMath_common.h
+++ b/dag_vecMath_common.h
@@ -27,6 +27,13 @@ NO_ASAN_INLINE vec3f v_ldu_p3(const float *m)
 }
 NO_ASAN_INLINE vec3f v_ldu_p3_safe(const float *m) { return v_perm_xyab(v_ldu_half(m), v_ldu_x(m + 2)); }
 
+VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f_mask(uint8_t bitmask)
+{
+  vec4i lookup = v_make_vec4i(1 << 0, 1 << 1, 1 << 2, 1 << 3);
+  vec4i isolated = v_andi(v_splatsi(bitmask), lookup);
+  return v_cvt_vec4f(v_cmp_eqi(isolated, lookup));
+}
+
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_le(vec4f a, vec4f b) { return v_cmp_ge(b, a); }
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_lt(vec4f a, vec4f b) { return v_cmp_gt(b, a); }
 
@@ -203,18 +210,25 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f c
 }
 #endif
 
+VECMATH_FINLINE vec4f VECTORCALL v_remove_not_finite(vec4f a)
+{
+  static vec4i_const infMask = { 0x7F800000, 0x7F800000, 0x7F800000, 0x7F800000 };
+  vec4i ai = v_cast_vec4i(a);
+  return v_cast_vec4f(v_andnoti(v_cmp_eqi(v_andi(ai, infMask), infMask), ai));
+}
+
 #if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__ > 0 // Clang/GCC
 VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a)
 {
-  static vec4i_const nanMask = { 0x7FC00000, 0x7FC00000, 0x7FC00000, 0x7FC00000 };
-  vec4i ai = v_cast_vec4i(a);
-  return v_cast_vec4f(v_andi(ai, v_cmp_lti(v_andi(ai, nanMask), nanMask)));
+  static vec4i_const minNan = { 0x7F800001, 0x7F800001, 0x7F800001, 0x7F800001 };
+  vec4i am = v_andi(v_cast_vec4i(a), V_CI_INV_SIGN_MASK);
+  return v_cast_vec4f(v_andi(v_cast_vec4i(a), v_cmp_lti(am, minNan)));
 }
 #else
 VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a) {return v_and(a, v_cmp_eq(a,a)); }
 #endif
-VECMATH_FINLINE vec4f VECTORCALL v_norm4_safe(vec4f a) {return v_remove_nan(v_norm4(a));}
-VECMATH_FINLINE vec4f VECTORCALL v_norm3_safe(vec4f a) {return v_remove_nan(v_norm3(a));}
+VECMATH_FINLINE vec4f VECTORCALL v_norm4_safe(vec4f a) {return v_remove_not_finite(v_norm4(a));}
+VECMATH_FINLINE vec4f VECTORCALL v_norm3_safe(vec4f a) {return v_remove_not_finite(v_norm3(a));}
 
 VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, mat33f_cref src)
 {
@@ -228,11 +242,11 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_from_look(mat33f &dest, vec4f look_
 
 #if _TARGET_SIMD_SSE
   if (v_extract_x(vxlsq) < 1.42e-12F)
-    vx = v_norm3(v_cross3(v_sel(V_C_UNIT_0010, look_dir, v_msbit()), look_dir));
+    vx = v_norm3(v_cross3(v_btsel(V_C_UNIT_0010, look_dir, v_msbit()), look_dir));
   else
     vx = v_mul(vx, v_rsqrt4(vxlsq));
 #else
-  vec4f vx1 = v_norm3(v_cross3(v_sel(V_C_UNIT_0010, look_dir, v_msbit()), look_dir));
+  vec4f vx1 = v_norm3(v_cross3(v_btsel(V_C_UNIT_0010, look_dir, v_msbit()), look_dir));
   vec4f vx2 = v_mul(vx, v_rsqrt4(vxlsq));
   vx = v_sel(vx1, vx2, v_cmp_gt(vxlsq, v_zero()));
 #endif
@@ -563,6 +577,15 @@ VECMATH_FINLINE void VECTORCALL v_bbox3_add_transformed_box(bbox3f &b, mat44f_cr
 }
 
 VECMATH_FINLINE vec3f VECTORCALL v_bbox3_size(bbox3f_cref b) { return v_sub(b.bmax, b.bmin); }
+VECMATH_FINLINE bbox3f v_bbox3_scale(bbox3f_cref b, vec4f size_factor)
+{
+  vec3f center = v_bbox3_center(b);
+  return bbox3f
+  {
+    v_lerp_vec4f(size_factor, center, b.bmin),
+    v_lerp_vec4f(size_factor, center, b.bmax)
+  };
+}
 VECMATH_FINLINE vec4f VECTORCALL v_bbox3_test_pt_inside(bbox3f_cref b, vec3f p)
 {
   vec3f m = v_and(v_cmp_ge(p, b.bmin), v_cmp_ge(b.bmax, p));
@@ -584,6 +607,128 @@ VECMATH_FINLINE vec4f VECTORCALL v_bbox3_test_box_intersect_safe(bbox3f_cref b1,
   vec3f m = v_and(v_and(v_cmp_gt(b1.bmax, b1.bmin), v_cmp_gt(b2.bmax, b2.bmin)),
                   v_and(v_cmp_ge(b2.bmax, b1.bmin), v_cmp_ge(b1.bmax, b2.bmin)));
   return v_and(v_splat_x(m), v_and(v_splat_y(m), v_splat_z(m)));
+}
+
+inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, bbox3f box1, const mat44f& tm1)
+{
+  // fast check for box1 limits inside box0
+  vec3f lmin = v_mat44_mul_vec3p(tm1, box1.bmin);
+  vec3f lmax = v_mat44_mul_vec3p(tm1, box1.bmax);
+  if (v_bbox3_test_pt_inside_b(box0, lmin) || v_bbox3_test_pt_inside_b(box0, lmax))
+    return true;
+
+  vec3f msbit = v_msbit();
+  vec3f elemMask0 = v_cast_vec4f(v_seti_x(-1));
+
+  // testing intersection of 12 edges of box1 with 3 orthogonal planes of box0
+  for (int i = 0; i < 3; i++)
+  {
+    vec3f point0 = v_sel(v_zero(), box1.bmin, elemMask0);
+    vec3f point1 = v_sel(v_zero(), box1.bmax, elemMask0);
+    vec3f elemMask1 = v_perm_xycd(v_perm_xaxa(v_cmp_eq(elemMask0, v_zero()), v_xor(elemMask0, v_zero())), v_zero()); // take Y on pass 0, and X on others
+    vec3f elemMask2 = v_cmp_eq(v_or(elemMask0, elemMask1), v_zero());
+    elemMask0 = v_rot_3(elemMask0);
+
+    for (int j = 0; j < 2; j++)
+    {
+      vec3f box1LimJ = v_sel(box1.bmax, box1.bmin, v_cast_vec4f(v_splatsi(j - 1)));
+      point0 = v_sel(point0, box1LimJ, elemMask1);
+      point1 = v_sel(point1, box1LimJ, elemMask1);
+
+      for (int k = 0; k < 2; k++)
+      {
+        vec3f box1LimK = v_sel(box1.bmax, box1.bmin, v_cast_vec4f(v_splatsi(k - 1)));
+        point0 = v_sel(point0, box1LimK, elemMask2);
+        point1 = v_sel(point1, box1LimK, elemMask2);
+
+        // test segment point0-point1 against 3 orthogonal planes of box0
+        vec3f point0l = v_mat44_mul_vec3p(tm1, point0);
+        vec3f point1l = v_mat44_mul_vec3p(tm1, point1);
+        vec3f dir = v_sub(point1l, point0l);
+
+        vec3f dirGE0 = v_cmp_ge(dir, v_zero());
+        vec3f depth = v_sel(v_sub(point0l, box0.bmax),
+                            v_sub(box0.bmin, point0l),
+                            dirGE0);
+        vec3f length = v_abs(dir);
+        vec3f width = v_bbox3_size(box0);
+        vec3f nwidth = v_xor(width, msbit);
+        vec3f selectPi1 = v_and(v_cmp_gt(depth, v_zero()),
+                                v_cmp_lt(depth, length));
+        vec3f selectPi2 = v_and(v_cmp_gt(depth, nwidth),
+                                v_cmp_lt(v_sub(depth, length), nwidth));
+
+        vec3f validMask = v_or(selectPi1, selectPi2);
+        if ((v_signmask(validMask) & 7) == 0)
+          continue;
+
+        vec3f selectMask = v_xor(selectPi1, dirGE0);
+        vec3f lim = v_sel(box0.bmin, box0.bmax, selectMask);
+        vec3f t = v_div(v_sub(lim, point0l), v_and(dir, validMask)); // gen NaN's for invalid
+
+        vec3f px = v_sub(v_lerp_vec4f(v_splat_x(t), point0l, point1l),
+                         v_sel(box0.bmin, box0.bmax, v_splat_x(selectMask)));
+        vec3f py = v_sub(v_lerp_vec4f(v_splat_y(t), point0l, point1l),
+                         v_sel(box0.bmin, box0.bmax, v_splat_y(selectMask)));
+        vec3f pz = v_sub(v_lerp_vec4f(v_splat_z(t), point0l, point1l),
+                         v_sel(box0.bmin, box0.bmax, v_splat_z(selectMask)));
+
+        vec3f selectMaskSign = v_and(selectMask, msbit);
+        vec4f pxpy = v_perm_xycd(v_perm_yzxy(px), v_perm_xzxz(py)); // yzac
+        pxpy = v_xor(pxpy, v_perm_xxyy(selectMaskSign));
+        pz = v_xor(pz, v_splat_z(selectMaskSign));
+
+        vec4f crossXY = v_and(v_cmp_ge(pxpy, v_zero()),
+                              v_cmp_le(pxpy, v_perm_xycd(v_perm_yzxy(width), v_perm_xzxz(width)))); // yzxz
+        vec4f crossZ = v_and(v_cmp_ge(pz, v_zero()),
+                             v_cmp_le(pz, width));
+        uint8_t signMask = uint8_t(v_signmask(crossXY) | (v_signmask(crossZ) << 4));
+        if (signMask & (signMask >> 1) & (1 << 0 | 1 << 2 | 1 << 4))
+          return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
+                                                                        vec4f size_factor)
+{
+  // validate
+  vec3f width0 = v_bbox3_size(box0);
+  vec3f width1 = v_bbox3_size(box1);
+  if (v_signmask(v_or(width0, width1)) & (1 | 2 | 4)) // any of dimensions is negative
+    return false;
+
+  // check boundings don't intersect
+  vec4f box0max = v_max(v_abs(box0.bmin), v_abs(box0.bmax));
+  vec4f box1max = v_max(v_abs(box1.bmin), v_abs(box1.bmax));
+  vec4f r0 = v_length3_x(v_mat44_mul_vec3p(tm0, box0max));
+  vec4f r1 = v_length3_x(v_mat44_mul_vec3p(tm1, box1max));
+  vec4f r = v_mul_x(v_add_x(r0, r1), size_factor);
+  vec4f distSq = v_length3_sq_x(v_sub(tm1.col3, tm0.col3));
+  if (v_test_vec_x_gt(distSq, v_mul_x(r, r)))
+    return false;
+
+  // bbox intersection check
+  mat44f tm;
+  v_mat44_inverse43(tm, tm0);
+  v_mat44_mul(tm, tm, tm1);
+  if (v_bbox3_test_trasformed_box_intersect_b(v_bbox3_scale(box0, size_factor), box1, tm))
+    return true;
+
+  v_mat44_inverse43(tm, tm1);
+  v_mat44_mul(tm, tm, tm0);
+  if (v_bbox3_test_trasformed_box_intersect_b(v_bbox3_scale(box1, size_factor), box0, tm)) //-V764 box1, box order is correct
+    return true;
+
+  return false;
+}
+
+VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_b(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1)
+{
+  return v_bbox3_test_trasformed_box_intersect_b(box0, tm0, box1, tm1, v_splats(1.f));
 }
 
 VECMATH_FINLINE int VECTORCALL v_bbox3_test_sph_intersect(bbox3f_cref box, vec4f bsph_r2)
@@ -1099,7 +1244,7 @@ VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v) { return (unsigned
 #else
 VECMATH_FINLINE int VECTORCALL v_test_vec_mask_eq_0(vec4f v)
 {
-  return v_test_vec_x_eq_0(v_cast_vec4f(v_srli(v_cast_vec4i(vis_hor_or_ff_0(v)), 31)));
+  return v_test_vec_x_eqi_0(v_cast_vec4f(v_srli(v_cast_vec4i(vis_hor_or_ff_0(v)), 31)));
 }
 
 VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v)
@@ -1113,7 +1258,7 @@ VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v)
 ///return zero if not visible. 0xff in all bytes, otherwise
 ///really fast, ~0.075 us per test on PS3
 
-///for branching: (~v_test_vec_x_eq_0( v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
+///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
 VECMATH_FINLINE vec4f VECTORCALL v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f zero = v_zero();
@@ -1198,7 +1343,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cre
 VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f ret = v_is_visible(bmin, bmax, clip);
-  return (~v_test_vec_x_eq_0(ret))&1;
+  return (~v_test_vec_x_eqi_0(ret))&1;
 }
 #endif
 
@@ -1530,7 +1675,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f thr
 
   vec4f nout = v_and(nout012, nout345);
 
-  if (v_test_vec_x_eq_0(nout)) //"not outside"=0 -> outside=1
+  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
     return 0;
 
 #endif
@@ -1545,7 +1690,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f thr
   #else
   valid_cs = v_and(valid_cs, v_rot_1(valid_cs));//xy, yz, zw, wx
   valid_cs = v_and(valid_cs, v_rot_2(valid_cs));//xyzw,yzwx, zwxy, wxyz
-  if (v_test_vec_x_eq_0(valid_cs))
+  if (v_test_vec_x_eqi_0(valid_cs))
   #endif
   {
     screen_box = *(vec4f*)v_screen_full_screen;
@@ -1576,7 +1721,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f thr
     return 0;
   #else
   screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eq_0(screenSizeVisible))
+  if (!v_test_vec_x_eqi_0(screenSizeVisible))
     return 0;
   #endif
   return 1;
@@ -1636,7 +1781,7 @@ VECMATH_FINLINE int VECTORCALL
 
   vec4f nout = v_and(nout012, nout345);
 
-  if (v_test_vec_x_eq_0(nout)) //"not outside"=0 -> outside=1
+  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
     return 0;
 
 #endif
@@ -1680,7 +1825,7 @@ VECMATH_FINLINE int VECTORCALL
     return 0;
   #else
   screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eq_0(screenSizeVisible))
+  if (!v_test_vec_x_eqi_0(screenSizeVisible))
     return 0;
   #endif
   return 1;
@@ -1737,7 +1882,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f box2_xyXY, vec3f threshold,
 
   vec4f nout = v_and(nout012, nout345);
 
-  if (v_test_vec_x_eq_0(nout)) //"not outside"=0 -> outside=1
+  if (v_test_vec_x_eqi_0(nout)) //"not outside"=0 -> outside=1
     return 0;
 
 #endif
@@ -1750,7 +1895,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f box2_xyXY, vec3f threshold,
   #else
   valid_cs = v_and(valid_cs, v_rot_1(valid_cs));//xy, yz, zw, wx
   valid_cs = v_and(valid_cs, v_rot_2(valid_cs));//xyzw,yzwx, zwxy, wxyz
-  if (v_test_vec_x_eq_0(valid_cs))
+  if (v_test_vec_x_eqi_0(valid_cs))
   #endif
   {
     screen_box = *(vec4f*)v_screen_full_screen;
@@ -1776,7 +1921,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f box2_xyXY, vec3f threshold,
     return 0;
   #else
   screenSizeVisible = v_or(screenSizeVisible, v_rot_1(screenSizeVisible));
-  if (!v_test_vec_x_eq_0(screenSizeVisible))
+  if (!v_test_vec_x_eqi_0(screenSizeVisible))
     return 0;
   #endif
   return 1;
@@ -1805,8 +1950,7 @@ VECMATH_INLINE int VECTORCALL v_test_segment_box_intersection_dir(vec3f start, v
   lmin = v_max(lmin0, lmin);
   #if !_TARGET_SIMD_SSE
   vec4f result = v_and(v_and(v_cmp_ge(lmax, v_zero()), v_cmp_ge(lmax, lmin)), v_cmp_ge(V_C_ONE, lmin));
-  result = v_splat_x(result);
-  return !v_test_vec_x_eq_0(result);
+  return !v_test_vec_x_eqi_0(result);
   #else
   vec4f result = v_and(v_and(_mm_cmpge_ss(lmax, v_zero()), _mm_cmpge_ss(lmax, lmin)), _mm_cmpge_ss(V_C_ONE, lmin));
   return _mm_movemask_ps(result)&1;
@@ -1816,6 +1960,75 @@ VECMATH_INLINE int VECTORCALL v_test_segment_box_intersection_dir(vec3f start, v
 VECMATH_FINLINE int VECTORCALL v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f_cref box)
 {
   return v_test_segment_box_intersection_dir(start, v_sub(end, start), box);
+}
+
+// return -1 if no intersection found, or box side index in [0; 5] and output param 'at' in range [0.0; 1.0]
+inline int VECTORCALL v_test_segment_box_intersection_side(vec3f start, vec3f end, bbox3f_cref box, float& out_at)
+{
+  int ret = -1;
+  out_at = v_extract_x(V_C_MAX_VAL);
+  vec3f fullDir = v_sub(end, start);
+
+  for (int i = 0; i < 2; i++)
+  {
+    vec3f blim = v_sel(box.bmax, box.bmin, v_cast_vec4f(v_splatsi(i == 0 ? -1 : 0)));
+    vec3f v1 = v_sub(start, blim);
+    vec3f v2 = v_sub(v_add(start, fullDir), blim);
+    vec3f numerator = v_sub(blim, start);
+    vec3f valid = v_and(v_cmp_gt(v_abs(fullDir), V_C_EPS_VAL),
+                        v_or(v_cmp_le(v_abs(v2), V_C_EPS_VAL),
+                             v_cmp_le(v_mul(v1, v2), v_zero())));
+
+    vec3f at = v_div(numerator, fullDir);
+    valid = v_and(valid, v_cmp_ge(at, v_zero()));
+    if (v_signmask(valid) == 0)
+      continue;
+
+    vec3f p0 = v_madd(fullDir, v_splat_x(at), start);
+    vec3f p1 = v_madd(fullDir, v_splat_y(at), start);
+    vec3f p2 = v_madd(fullDir, v_splat_z(at), start);
+
+    vec4f box0min = v_perm_xyab(v_perm_yzwx(box.bmin), v_perm_yzwx(p0));
+    vec4f box0max = v_perm_xyab(v_perm_yzwx(p0), v_perm_yzwx(box.bmax));
+    vec4f box1min = v_perm_xyab(v_perm_zxyw(box.bmin), v_perm_zxyw(p1));
+    vec4f box1max = v_perm_xyab(v_perm_zxyw(p1), v_perm_zxyw(box.bmax));
+    vec4f box2min = v_perm_xyab(box.bmin, p2);
+    vec4f box2max = v_perm_xyab(p2, box.bmax);
+
+    vec3f b0valid = v_cmp_gt(box0max, box0min);
+    vec3f b1valid = v_cmp_gt(box1max, box1min);
+    vec3f b2valid = v_cmp_gt(box2max, box2min);
+
+    b0valid = v_and(b0valid, v_rot_1(b0valid));
+    b1valid = v_and(b1valid, v_rot_1(b1valid));
+    b2valid = v_and(b2valid, v_rot_1(b2valid));
+    b0valid = v_and(b0valid, v_rot_2(b0valid));
+    b1valid = v_and(b1valid, v_rot_2(b1valid));
+    b2valid = v_and(b2valid, v_rot_2(b2valid));
+    vec3f b012valid = v_perm_xyab(v_perm_xaxa(b0valid, b1valid), b2valid);
+
+    at = v_sel(V_C_MAX_VAL, at, v_and(valid, b012valid));
+    vec3f bestMinMask = v_and(v_cmp_le(at, v_perm_yzxw(at)),
+                              v_cmp_le(at, v_perm_zxyw(at)));
+
+    int selectMask = v_signmask(bestMinMask) & (1 | 2 | 4);
+    if (selectMask != 0)
+    {
+      alignas(16) float at4[4];
+      v_st(at4, at);
+#if defined(__clang__) || defined(__GNUC__)
+      int select = __builtin_ctz(selectMask);
+#else
+      unsigned long select;
+      _BitScanForward(&select, selectMask);
+#endif
+      if (at4[select] < out_at)
+        ret = select + i * 3;
+      out_at = out_at < at4[select] ? out_at : at4[select];
+    }
+  }
+
+  return ret;
 }
 
 VECMATH_FINLINE bool VECTORCALL v_test_segment_sphere_intersection_dir_t(vec3f p0,
@@ -1863,6 +2076,7 @@ VECMATH_INLINE bool VECTORCALL v_test_ray_sphere_intersection_b(vec3f p0,
   return v_test_vec_x_le(v_length3_sq(v_sub(v_mul(normalized_dir, t), ap)), sphere_r2);
 }
 
+#if !_TARGET_SIMD_SSE
 VECMATH_FINLINE void VECTORCALL v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm)
 {
   v_mat_43cu_from_mat44(m43, tm);
@@ -1874,14 +2088,6 @@ VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, co
   v_stu_p3(m43 + 3, tm.col1);
   v_stu_p3(m43 + 6, tm.col2);
   v_stu_p3(m43 + 9, tm.col3);
-}
-
-VECMATH_FINLINE void VECTORCALL v_mat_44cu_from_mat44(float* __restrict m44, const mat44f& tm)
-{
-  v_stu(m44 + 0,  tm.col0);
-  v_stu(m44 + 4,  tm.col1);
-  v_stu(m44 + 8,  tm.col2);
-  v_stu(m44 + 12, tm.col3);
 }
 
 //mat44f from unaligned TMatrix
@@ -1900,6 +2106,26 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float 
   tmV.col1 = v_and(v_ldu(m43+3), (vec4f)V_CI_MASK1110);
   tmV.col2 = v_and(v_ldu(m43+6), (vec4f)V_CI_MASK1110);
   tmV.col3 = v_add(v_and(v_rot_1(v_ldu(m43+8)), (vec4f)V_CI_MASK1110), V_C_UNIT_0001);
+}
+#endif // !_TARGET_SIMD_SSE
+
+VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43)
+{
+  vec4f v0 = v_ldu(m43 + 0);
+  vec4f v1 = v_ldu(m43 + 4);
+  vec4f v2 = v_ldu(m43 + 8);
+  tmV.col0 = v0;
+  tmV.col1 = v_perm_wxyz(v_perm_xycd(v1, v0));
+  tmV.col2 = v_perm_zwxy(v_perm_xycd(v2, v1));
+  tmV.col3 = v_rot_1(v2);
+}
+
+VECMATH_FINLINE void VECTORCALL v_mat_44cu_from_mat44(float* __restrict m44, const mat44f& tm)
+{
+  v_stu(m44 + 0, tm.col0);
+  v_stu(m44 + 4, tm.col1);
+  v_stu(m44 + 8, tm.col2);
+  v_stu(m44 + 12, tm.col3);
 }
 
 //mat44f from unaligned 4x4 matrix
@@ -2204,7 +2430,7 @@ VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& 
   d1 = v_sel(d1, p1, mask);
   d2 = v_sel(d2, edge1, mask);
   mask1 = v_or(mask1, mask);
-  if (!v_test_vec_x_eq_0(mask1))
+  if (!v_test_vec_x_eqi_0(mask1))
     return v_add(d1, v_mul(d2, V_C_HALF));//radius = 0.5*length(d2);
   vec3f c1  = v_mul(nd2, nd3);
   vec3f c2  = v_mul(nd3, nd1);
@@ -2217,6 +2443,21 @@ VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& 
                      v_mul(p3, v_add(c1, c2))
                      ),
                cmul2);//r       = 0.5f * sqrt( fabsf(safediv((nd1 + nd2) * (nd2 + nd3) * (nd3 + nd1), c)) );
+}
+
+VECMATH_INLINE bool VECTORCALL v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3)
+{
+  vec3f t123y = v_perm_xyab(v_perm_xaxa(v_splat_y(t1), v_splat_y(t2)), v_splat_y(t3));
+  vec3f t123x = v_perm_xyab(v_perm_xaxa(t1, t2), t3);
+  vec3f t231y = v_perm_yzxw(t123y);
+  vec3f t231x = v_perm_yzxw(t123x);
+  vec3f a = v_sub(t231y, t123y);
+  vec3f b = v_sub(t231x, t123x);
+  vec3f c = v_sub(v_mul(b, t123y), v_mul(a, t123x));
+  vec3f d = v_sub(v_mul(a, v_splat_x(p)), v_mul(b, v_splat_y(p)));
+  vec3f e = v_add(c, d);
+  int signMask = v_signmask(e) & (1 | 2 | 4);
+  return signMask == 0 || signMask == (1 | 2 | 4);
 }
 
 //this is ~3 times faster for valid floats (not nans, infs, etc), than int(floorf())

--- a/dag_vecMath_neon.h
+++ b/dag_vecMath_neon.h
@@ -81,6 +81,7 @@ VECMATH_FINLINE int VECTORCALL v_signmask(vec4f V)
 }
 
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b) { return (vec4f)vceqq_f32(a, b); }
+VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b) { return (vec4f)vmvnq_u32(vceqq_f32(a, b)); }
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b) { return (vec4f)vceqq_s32((vec4i)a, (vec4i)b); }
 VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b) { return (vec4i)vceqq_s32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_ge(vec4f a, vec4f b) { return (vec4f)vcgeq_f32(a, b); }
@@ -92,9 +93,13 @@ VECMATH_FINLINE vec4f VECTORCALL v_and(vec4f a, vec4f b) { return (vec4f)vandq_s
 VECMATH_FINLINE vec4f VECTORCALL v_andnot(vec4f a, vec4f b) { return (vec4f)vandq_s32(vmvnq_s32((vec4i)a), (vec4i)b); }
 VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b) { return (vec4f)vorrq_s32((vec4i)a, (vec4i)b); }
 VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b) { return (vec4f)veorq_s32((vec4i)a, (vec4i)b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c) { return vbslq_f32((uint32x4_t)c, b, a); }
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)c, b, a); }
-VECMATH_FINLINE float32x2_t VECTORCALL v_sel2(float32x2_t a, float32x2_t b, int32x2_t c) { return vbsl_f32((uint32x2_t)c, b, a); }
+VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c)
+{
+  return vbslq_f32((uint32x4_t)vshrq_n_s32(vreinterpretq_s32_f32(c), 31), b, a);
+}
+VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)vshrq_n_s32(c, 31), b, a); }
+VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c) { return vbslq_f32((uint32x4_t)c, b, a); }
+VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)c, b, a); }
 
 VECMATH_FINLINE int VECTORCALL v_check_xyz_non_zero(vec4f a)
 {
@@ -174,11 +179,13 @@ VECMATH_FINLINE vec4f VECTORCALL v_add(vec4f a, vec4f b) { return vaddq_f32(a, b
 VECMATH_FINLINE vec4f VECTORCALL v_sub(vec4f a, vec4f b) { return vsubq_f32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_mul(vec4f a, vec4f b) { return vmulq_f32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
 VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b) { return vaddq_f32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b) { return vsubq_f32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b) { return vmulq_f32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
 VECMATH_FINLINE vec4f VECTORCALL v_nmsub_x(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
 
 VECMATH_FINLINE vec4i VECTORCALL v_addi(vec4i a, vec4i b) { return vaddq_s32(a, b); }
@@ -893,10 +900,14 @@ VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad(vec3f bmin, vec3f bmax)
 {
   return v_mul(V_C_HALF, v_length3(v_sub(bmax, bmin)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(vec3f bmin, vec3f bmax)
+VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_diameter(vec3f bmin, vec3f bmax)
 {
   vec4f s = v_sub(bmax, bmin);
-  return v_mul(V_C_HALF, v_min(s, v_min(v_rot_1(s), v_rot_2(s))));
+  return v_min(s, v_min(v_rot_1(s), v_rot_2(s)));
+}
+VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(vec3f bmin, vec3f bmax)
+{
+  return v_mul(V_C_HALF, v_bbox3_inner_diameter(bmin, bmax));
 }
 
 VECMATH_FINLINE int VECTORCALL v_check_xz_non_zero(vec4f a)
@@ -998,20 +1009,6 @@ VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat(vec3f col0, vec3f col1, vec
 
 VECMATH_FINLINE short VECTORCALL v_extract_xi16(vec4i v) { return vgetq_lane_s16(vreinterpretq_s16_s32(v), 0); }
 
-VECMATH_FINLINE float VECTORCALL v_extract(vec4f v, int i)
-{
-  alignas(16) float a[4];
-  v_st(a, v);
-  return a[i];
-}
-
-VECMATH_FINLINE int VECTORCALL v_extracti(vec4i v, int i)
-{
-  alignas(16) int a[4];
-  v_sti(a, v);
-  return a[i];
-}
-
 VECMATH_FINLINE float VECTORCALL v_extract_x(vec4f v) { return vgetq_lane_f32(v, 0); }
 VECMATH_FINLINE float VECTORCALL v_extract_y(vec4f v) { return vgetq_lane_f32(v, 1); }
 VECMATH_FINLINE float VECTORCALL v_extract_z(vec4f v) { return vgetq_lane_f32(v, 2); }
@@ -1026,12 +1023,18 @@ VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i v) {return vgetq_lane_s6
 
 #define V_TEST_VEC_X_BIT0(v) (vget_lane_u32(v, 0) & 1)
 
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a)
+{
+  return V_TEST_VEC_X_BIT0(vceq_s32(vget_low_f32(v), vget_low_f32(a)));
+}
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
+
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vget_low_f32(a))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vget_low_f32(a))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vget_low_f32(a))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vget_low_f32(a))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_le(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcle_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq_0(vec3f v) { return V_TEST_VEC_X_BIT0(vceq_s32(vget_low_s32((vec4i)v), vmov_n_s32(0))); }
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq_0(vec3f v) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vmov_n_f32(0))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vmov_n_f32(0))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vmov_n_f32(0))); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vmov_n_f32(0))); }

--- a/dag_vecMath_pc_sse.h
+++ b/dag_vecMath_pc_sse.h
@@ -33,6 +33,9 @@
 #include <pmmintrin.h>
 #include <tmmintrin.h>
 #endif
+#if defined(__FMA__) || defined(__AVX__) || defined(__AVX2__)
+#include <immintrin.h>
+#endif
 
 #ifdef _MSC_VER
   #pragma warning(push)
@@ -142,6 +145,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_merge_lw(vec4f a, vec4f b) { return _mm_unpac
 
 VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a) { return _mm_movemask_ps(a); }
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b) { return _mm_cmpeq_ps(a, b); }
+VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b) { return _mm_cmpneq_ps(a, b); }
 VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b) { return _mm_cmpeq_epi32(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b)
 {
@@ -156,12 +160,12 @@ VECMATH_FINLINE vec4f VECTORCALL v_and(vec4f a, vec4f b) { return _mm_and_ps(a,b
 VECMATH_FINLINE vec4f VECTORCALL v_andnot(vec4f a, vec4f b) { return _mm_andnot_ps(a,b); }
 VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b) { return _mm_or_ps(a,b); }
 VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b) { return _mm_xor_ps(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c)
+VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c)
 {
   return _mm_or_ps(_mm_and_ps(c, b), _mm_andnot_ps(c, a));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
+VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c)
 {
   return _mm_or_si128(_mm_and_si128(c, b), _mm_andnot_si128(c, a));
 }
@@ -218,12 +222,27 @@ VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a) {return sse4_cvt_ceili(a);
 VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a) { return sse4_floor(a); }
 VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a) { return sse4_ceil(a); }
 VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a) { return sse4_round(a); }
+VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c) { return _mm_blendv_ps(a, b, c); }
+VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
+{
+  return _mm_castps_si128(_mm_blendv_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), _mm_castsi128_ps(c)));
+}
 #else
 VECMATH_FINLINE vec4i VECTORCALL v_cvt_floori(vec4f a) {return sse2_cvt_floori(a);}
 VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a) {return sse2_cvt_ceili(a);}
 VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a) { return sse2_floor(a); }
 VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a) { return sse2_ceil(a); }
 VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a) { return sse2_round(a); }
+VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c)
+{
+  vec4f m = _mm_castsi128_ps(_mm_srai_epi32(_mm_castps_si128(c), 31));
+  return _mm_or_ps(_mm_and_ps(m, b), _mm_andnot_ps(m, a));
+}
+VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
+{
+  vec4i m = _mm_srai_epi32(c, 31);
+  return _mm_or_si128(_mm_and_si128(m, b), _mm_andnot_si128(m, a));
+}
 #endif
 
 
@@ -231,13 +250,22 @@ VECMATH_FINLINE vec4f VECTORCALL v_add(vec4f a, vec4f b) { return _mm_add_ps(a, 
 VECMATH_FINLINE vec4f VECTORCALL v_sub(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_mul(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_div(vec4f a, vec4f b) { return _mm_div_ps(a, b); }
+#if defined(__FMA__) || defined(__AVX2__)
+VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); }
+VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ss(a, b, c); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ss(a, b, c); }
+#else
 VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return _mm_add_ps(_mm_mul_ps(a, b), c); }
+VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_add_ss(_mm_mul_ss(a, b), c); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(_mm_mul_ps(a, b), c); }
+VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(_mm_mul_ss(a, b), c); }
+#endif
 VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(c, _mm_mul_ps(a, b)); }
 VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b) { return _mm_add_ss(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b) { return _mm_sub_ss(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b) { return _mm_mul_ss(a, b); }
 VECMATH_FINLINE vec4f VECTORCALL v_div_x(vec4f a, vec4f b) { return _mm_div_ss(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_add_ss(_mm_mul_ss(a, b), c); }
 VECMATH_FINLINE vec4f VECTORCALL v_nmsub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(c, _mm_mul_ss(a, b)); }
 VECMATH_FINLINE vec4i VECTORCALL v_addi(vec4i a, vec4i b) { return _mm_add_epi32(a, b); }
 VECMATH_FINLINE vec4i VECTORCALL v_subi(vec4i a, vec4i b) { return _mm_sub_epi32(a, b); }
@@ -591,6 +619,50 @@ VECMATH_FINLINE vec3f VECTORCALL v_cross3(vec3f a, vec3f b)
   );
 }
 
+VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f& tm, const float *const __restrict m43)
+{
+  v_mat44_make_from_43cu(tm, m43);
+}
+
+VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f& tm, const float *const __restrict m43)
+{
+  vec4f v0 = v_ldu(m43 + 0);
+  vec4f v1 = v_ldu(m43 + 4);
+  vec4f v2 = v_ldu(m43 + 8);
+#if _TARGET_SIMD_SSE >= 4
+  tm.col0 = _mm_blend_ps(v0, v_zero(), 1 << 3);
+  tm.col1 = _mm_insert_ps(_mm_shuffle_ps(v1, v1, _MM_SHUFFLE(2, 1, 0, 3)), v0, _MM_MK_INSERTPS_NDX(3, 0, 1 << 3));
+  tm.col2 = _mm_blend_ps(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), v_zero(), 1 << 3);
+  tm.col3 = v_rot_1(_mm_move_ss(v2, v_cast_vec4f(v_seti_x(0x3f800000))));
+#else // _TARGET_SIMD_SSE >= 4
+  vec4f v10 = _mm_shuffle_ps(v1, v0, _MM_SHUFFLE(3, 2, 1, 0));
+  tm.col0 = v_and(v0, V_CI_MASK1110);
+  tm.col1 = v_and(_mm_shuffle_ps(v10, v10, _MM_SHUFFLE(2, 1, 0, 3)), V_CI_MASK1110);
+  tm.col2 = v_and(_mm_shuffle_ps(v1, v2, _MM_SHUFFLE(1, 0, 3, 2)), V_CI_MASK1110);
+  tm.col3 = v_rot_1(_mm_move_ss(v2, v_cast_vec4f(v_seti_x(0x3f800000))));
+#endif // _TARGET_SIMD_SSE >= 4
+}
+
+VECMATH_FINLINE void VECTORCALL v_mat_43ca_from_mat44(float * __restrict m43, const mat44f& tm)
+{
+  v_mat_43cu_from_mat44(m43, tm);
+}
+
+VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, const mat44f& tm)
+{
+#if _TARGET_SIMD_SSE >= 4
+  vec4f v0 = _mm_insert_ps(tm.col0, tm.col1, _MM_MK_INSERTPS_NDX(0, 3, 0));
+  vec4f v1 = v_perm_xyab(v_rot_1(tm.col1), tm.col2);
+  vec4f v2 = _mm_insert_ps(_mm_castsi128_ps(_mm_slli_si128(_mm_castps_si128(tm.col3), 4)), tm.col2, _MM_MK_INSERTPS_NDX(2, 0, 0));
+#else // _TARGET_SIMD_SSE >= 4
+  vec4f v0 = v_perm_xyzd(tm.col0, v_splat_x(tm.col1));
+  vec4f v1 = v_perm_xyab(v_rot_1(tm.col1), tm.col2);
+  vec4f v2 = _mm_move_ss(_mm_castsi128_ps(_mm_slli_si128(_mm_castps_si128(tm.col3), 4)), v_splat_z(tm.col2));
+#endif // _TARGET_SIMD_SSE >= 4
+  v_stu(m43 + 0, v0);
+  v_stu(m43 + 4, v1);
+  v_stu(m43 + 8, v2);
+}
 
 VECMATH_FINLINE void VECTORCALL v_mat44_ident(mat44f &dest)
 {
@@ -886,12 +958,16 @@ VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad(vec3f bmin, vec3f bmax)
 {
   return v_mul_x(V_C_HALF, v_length3_x(v_sub(bmax, bmin)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(vec3f bmin, vec3f bmax)
+VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_diameter(vec3f bmin, vec3f bmax)
 {
   vec4f s = v_sub(bmax, bmin);
-  return _mm_mul_ss(V_C_HALF, _mm_min_ss(s,
+  return _mm_min_ss(s,
                     _mm_min_ss(V_SHUFFLE_REV(s, 0, 0, 0, 1),
-                               _mm_shuffle_ps(s, s, _MM_SHUFFLE(0,0,0,2)))));
+                               _mm_shuffle_ps(s, s, _MM_SHUFFLE(0,0,0,2))));
+}
+VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(vec3f bmin, vec3f bmax)
+{
+  return _mm_mul_ss(V_C_HALF, v_bbox3_inner_diameter(bmin, bmax));
 }
 VECMATH_FINLINE int VECTORCALL v_bbox3_test_pt_inside_b(bbox3f_cref b, vec3f p)
 {
@@ -944,20 +1020,17 @@ VECMATH_FINLINE float VECTORCALL v_extract_z( vec4f a ) { return _mm_cvtss_f32(v
 VECMATH_FINLINE float VECTORCALL v_extract_w( vec4f a ) { return _mm_cvtss_f32(v_splat_w(a)); }
 #endif
 
-#if defined(__GNUC__) || defined(__clang__)
-VECMATH_FINLINE float VECTORCALL v_extract(vec4f v, int i) { alignas(16) float r[4]; _mm_store_ps(r, v); return r[i]; }
-VECMATH_FINLINE int VECTORCALL v_extracti(vec4i v, int i) { alignas(16) int r[4]; _mm_store_si128((__m128i*)r, v); return r[i]; }
-#else
-VECMATH_FINLINE float VECTORCALL v_extract(vec4f v, int i) { return v.m128_f32[i]; }
-VECMATH_FINLINE int VECTORCALL v_extracti(vec4i v, int i) { return v.m128i_i32[i]; }
-#endif
-
 VECMATH_FINLINE int VECTORCALL v_extract_xi(vec4i v) {return _mm_cvtsi128_si32(v);}
+#if _TARGET_SIMD_SSE >= 4
+VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v) {return _mm_extract_epi32(v, 1);}
+VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v) {return _mm_extract_epi32(v, 2);}
+VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v) {return _mm_extract_epi32(v, 3);}
+VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i v) {return _mm_extract_epi64(v, 0);}
+#else
 VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(1,1,1,1)));}
 VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(2,2,2,2)));}
 VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(3,3,3,3)));}
-
-VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64 ( vec4i a )
+VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i a)
 {
 #if defined(_MSC_VER) && !defined(__clang__)//visual studio is not capable of produce reasonable code otherwise!
     return a.m128i_i64[0];
@@ -965,16 +1038,20 @@ VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64 ( vec4i a )
     int64_t t; _mm_storel_epi64((__m128i*)&t, a); return t;
 #endif
 }
+#endif
+
 VECMATH_FINLINE vec4i VECTORCALL v_splatsi64(int64_t a) { return _mm_set1_epi64x(a); }
 
 VECMATH_FINLINE short VECTORCALL v_extract_xi16(vec4i v) {return (short)_mm_extract_epi16(v, 0);}
 
-
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a)
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a)
 {
   vec4i eq = _mm_cmpeq_epi32(v_cast_vec4i(v),v_cast_vec4i(a));
-  return _mm_movemask_ps(v_cast_vec4f(eq))&1;
+  return v_extract_xi(eq) ? 1 : 0;
 }
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
+
+VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a) { return _mm_comieq_ss(v,a); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt(vec3f v, vec3f a) { return _mm_comigt_ss(v,a); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge(vec3f v, vec3f a) { return _mm_comige_ss(v,a); }
 VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt(vec3f v, vec3f a) { return _mm_comilt_ss(v,a); }

--- a/dag_vecMath_trig.h
+++ b/dag_vecMath_trig.h
@@ -62,7 +62,7 @@ VECMATH_FINLINE void VECTORCALL v_sincos4(vec4f ang, vec4f& s, vec4f& c)
   vec4f vzero = v_zero();
 
   xl = v_mul(ang, V_C_2_DIV_PI);
-  xl = v_add(xl, v_sel(V_C_HALF, ang, v_msbit()));
+  xl = v_add(xl, v_btsel(V_C_HALF, ang, v_msbit()));
 
   q = v_cvt_vec4i(xl);
 


### PR DESCRIPTION
Old bit v_sel renamed to v_btsel, now v_sel work with dwords
Added v_cmp_neq, v_bbox3_inner_diameter, v_make_vec4f_mask, v_remove_not_finite
Optimized matrices load/save on SSE4
Added v_mat44_make_from_43cu_unsafe for mat44f load without row3 set
Now v_test_vec_x_eq doing float cmp, use v_test_vec_x_eqi for integer cmp
Added v_bbox3_test_trasformed_box_intersect_b, v_test_segment_box_intersection_side
Added v_is_point_in_triangle_2d
Bugfixes