### PR TITLE
Update to upstream 21-dec-2023

### DIFF
--- a/dag_vecMath.h
+++ b/dag_vecMath.h
@@ -12,15 +12,15 @@
 //
 
 //! 0
-VECMATH_FINLINE vec4f VECTORCALL v_zero();
-VECMATH_FINLINE vec4i VECTORCALL v_zeroi();
+VECTORCALL VECMATH_FINLINE vec4f v_zero();
+VECTORCALL VECMATH_FINLINE vec4i v_zeroi();
 //! ~0
-VECMATH_FINLINE vec4f VECTORCALL v_set_all_bits();
-VECMATH_FINLINE vec4i VECTORCALL v_set_all_bitsi();
+VECTORCALL VECMATH_FINLINE vec4f v_set_all_bits();
+VECTORCALL VECMATH_FINLINE vec4i v_set_all_bitsi();
 //! 0x80000000
-VECMATH_FINLINE vec4f VECTORCALL v_msbit();
+VECTORCALL VECMATH_FINLINE vec4f v_msbit();
 //! .xyzw = a[0]
-VECMATH_FINLINE vec4f VECTORCALL v_splat4(const float *a);
+VECTORCALL VECMATH_FINLINE vec4f v_splat4(const float *a);
 //! load vector from 16-byte aligned memory
 NO_ASAN_INLINE vec4f v_ld(const float *m);
 NO_ASAN_INLINE vec4i v_ldi(const int *m);
@@ -36,168 +36,168 @@ NO_ASAN_INLINE vec4i v_ldui_p3(const int *m);
 NO_ASAN_INLINE vec3f v_ldu_p3_safe(const float *m);
 NO_ASAN_INLINE vec4i v_ldui_p3_safe(const int *m);
 //! load unaligned memory and unpacks vector from 4 signed short ints
-VECMATH_FINLINE vec4i VECTORCALL v_ldush(const signed short *m);
+VECTORCALL VECMATH_FINLINE vec4i v_ldush(const signed short *m);
 //! load unaligned memory and unpacks vector from 4 unsigned short ints
-VECMATH_FINLINE vec4i VECTORCALL v_lduush(const unsigned short *m);
+VECTORCALL VECMATH_FINLINE vec4i v_lduush(const unsigned short *m);
 
 //! load 64 bit from unaligned memory into .xy (.zw=0)
-VECMATH_FINLINE vec4i VECTORCALL v_ldui_half(const void *m);
-VECMATH_FINLINE vec4f VECTORCALL v_ldu_half(const void *m);
+VECTORCALL VECMATH_FINLINE vec4i v_ldui_half(const void *m);
+VECTORCALL VECMATH_FINLINE vec4f v_ldu_half(const void *m);
 
 //! fetch the cache line that contains address m
 VECMATH_FINLINE void v_prefetch(const void *m);
 
 //! .xyzw = a.x
-VECMATH_FINLINE vec4f VECTORCALL v_splat_x(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_splat_xi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_splat_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_splat_xi(vec4i a);
 //! .xyzw = a.y
-VECMATH_FINLINE vec4f VECTORCALL v_splat_y(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_splat_yi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_splat_y(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_splat_yi(vec4i a);
 //! .xyzw = a.z
-VECMATH_FINLINE vec4f VECTORCALL v_splat_z(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_splat_zi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_splat_z(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_splat_zi(vec4i a);
 //! .xyzw = a.w
-VECMATH_FINLINE vec4f VECTORCALL v_splat_w(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_splat_wi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_splat_w(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_splat_wi(vec4i a);
 
 //! .xyzw = a
-VECMATH_FINLINE vec4f VECTORCALL v_splats(float a);
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi(int a);
+VECTORCALL VECMATH_FINLINE vec4f v_splats(float a);
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi(int a);
 //! .xyzw = {a64 a64}
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi64(int64_t a);
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi64(int64_t a);
 
 //! .xyzw = {a 0 0 0}
-VECMATH_FINLINE vec4f VECTORCALL v_set_x(float a);
-VECMATH_FINLINE vec4i VECTORCALL v_seti_x(int a);
+VECTORCALL VECMATH_FINLINE vec4f v_set_x(float a);
+VECTORCALL VECMATH_FINLINE vec4i v_seti_x(int a);
 
 //! .xyzw = {x y z w}
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f(float x, float y, float z, float w);
-VECMATH_FINLINE vec4i VECTORCALL v_make_vec4i(int x, int y, int z, int w);
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec4f(float x, float y, float z, float w);
+VECTORCALL VECMATH_FINLINE vec4i v_make_vec4i(int x, int y, int z, int w);
 
 //! .xyz = {x y z}
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(float x, float y, float z);
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(float x, float y, float z);
 //! .xyz = {x y z}, where .x component of each source vector used
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(vec4f x, vec4f y, vec4f z);
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z);
 
 //! unpack 4 low bits from bitmask to 4x32 bits mask, true=0xFFFFFFFF, false=0
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f_mask(uint8_t bitmask);
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec4f_mask(uint8_t bitmask);
 
 //! store vector to  16-byte aligned memory
-VECMATH_FINLINE void VECTORCALL v_st(void *m, vec4f v);
+VECTORCALL VECMATH_FINLINE void v_st(void *m, vec4f v);
 //! store vector to unaligned memory
-VECMATH_FINLINE void VECTORCALL v_stu(void *m, vec4f v);
+VECTORCALL VECMATH_FINLINE void v_stu(void *m, vec4f v);
 //! store low 64 bits of vector (.xy) to unaligned memory
-VECMATH_FINLINE void VECTORCALL v_stu_half(void *m, vec4f v);
+VECTORCALL VECMATH_FINLINE void v_stu_half(void *m, vec4f v);
 
 //! store vector to  16-byte aligned memory
-VECMATH_FINLINE void VECTORCALL v_sti(void *m, vec4i v);
+VECTORCALL VECMATH_FINLINE void v_sti(void *m, vec4i v);
 //! store vector to unaligned memory
-VECMATH_FINLINE void VECTORCALL v_stui(void *m, vec4i v);
+VECTORCALL VECMATH_FINLINE void v_stui(void *m, vec4i v);
 //! store low 64 bits of vector (.xy) to unaligned memory
-VECMATH_FINLINE void VECTORCALL v_stui_half(void *m, vec4i v);
+VECTORCALL VECMATH_FINLINE void v_stui_half(void *m, vec4i v);
 
 //! merge high words: .xyzw = {a.x, b.x, a.y, b.y}
-VECMATH_FINLINE vec4f VECTORCALL v_merge_hw(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_merge_hw(vec4f a, vec4f b);
 //! merge low words:  .xyzw = {a.z, b.z, a.w, b.w}
-VECMATH_FINLINE vec4f VECTORCALL v_merge_lw(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b);
 
 //! return signbit mask for each compnent - 1|2|4|8. ith bit is ith float signbit
-VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a);
+VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a);
 
 //! bitwise checks for whole register
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_zeros(vec4f a);
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_ones(vec4f a);
-VECMATH_FINLINE bool VECTORCALL v_test_any_bit_set(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_ones(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_test_any_bit_set(vec4f a);
 
 //! component-wise integer check x!=0 && y!=0 && z!=0 && w!=0
-VECMATH_FINLINE bool VECTORCALL v_check_xyzw_all_not_zeroi(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_check_xyzw_all_not_zeroi(vec4f a);
 
 //! component-wise integer check !x && !y && !z
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_zeroi(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_zeroi(vec4f a);
 //! component-wise integer check x && y && z
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_not_zeroi(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_not_zeroi(vec4f a);
 //! component-wise integer check x || y || z
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_any_not_zeroi(vec4f a);
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_any_not_zeroi(vec4f a);
 
 //! component-wise comparison: for C={xyzw}  .C = a.C==b.C ? 0xFFFFFFFF : 0
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eq(vec4f a, vec4f b);
 //! component-wise comparison: for C={xyzw}  .C = a.C!=b.C ? 0xFFFFFFFF : 0
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_neq(vec4f a, vec4f b);
 //! component-wise integer comparison: for C={xyzw}  .C = a.C==b.C ? 0xFFFFFFFF : 0
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b);
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eqi(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi(vec4i a, vec4i b);
 //! component-wise comparison: for C={xyzw}  .C = a.C>=b.C ? 0xFFFFFFFF : 0
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_ge(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_ge(vec4f a, vec4f b);
 //! component-wise comparison: for C={xyzw}  .C = a.C>b.C ? 0xFFFFFFFF : 0
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_gt(vec4f a, vec4f b);
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_gti(vec4i a, vec4i b);
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_lti(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_gt(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_gti(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_lti(vec4i a, vec4i b);
 
 //! a & b
-VECMATH_FINLINE vec4f VECTORCALL v_and(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_and(vec4f a, vec4f b);
 //! ~a & b
-VECMATH_FINLINE vec4f VECTORCALL v_andnot(vec4f a, vec4f b);
-VECMATH_FINLINE vec4i VECTORCALL v_andnoti(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4f v_andnot(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4i v_andnoti(vec4i a, vec4i b);
 //! a | b
-VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_or(vec4f a, vec4f b);
 //! a ^ b
-VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_xor(vec4f a, vec4f b);
 //! ~a
-VECMATH_FINLINE vec4f VECTORCALL v_not(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_not(vec4f a);
 //! component-wise select: for C={xyzw}  .C = c.C>=0 ? a.C : b.C
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c);
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c);
+VECTORCALL VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c);
 //! bit-wise select: for N={0..127}  .bitN = (c.bitN == 0) ? a.bitN : b.bitN
-VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c);
-VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c);
+VECTORCALL VECMATH_FINLINE vec4f v_btsel(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4i v_btseli(vec4i a, vec4i b, vec4i c);
 
 //! convert to integer using cast
-VECMATH_FINLINE vec4i VECTORCALL v_cast_vec4i(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_cast_vec4f(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cast_vec4i(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a);
 
 //! convert to integer using round-to-zero mode
-VECMATH_FINLINE vec4i VECTORCALL v_cvti_vec4i(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i(vec4f a);//works correctly on all correct values (positive). on negative - implementation defined
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i_ieee(vec4f a);//works same as scalar operations on all values
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_vec4i(vec4f a){return v_cvti_vec4i(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_cvti_vec4i(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a);//works correctly on all correct values (positive). on negative - implementation defined
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a);//works same as scalar operations on all values
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_vec4i(vec4f a){return v_cvti_vec4i(a);}
 //! convert to float
-VECMATH_FINLINE vec4f VECTORCALL v_cvti_vec4f(vec4i a);
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f(vec4i a);//works correctly on all accurately representable values (< 1<<24). on others - implementation defined
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f_ieee(vec4i a);//works same as scalar operations on all values
-VECMATH_FINLINE vec4f VECTORCALL v_cvt_vec4f(vec4i a) {return v_cvti_vec4f(a);}
+VECTORCALL VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f(vec4i a);//works correctly on all accurately representable values (< 1<<24). on others - implementation defined
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f_ieee(vec4i a);//works same as scalar operations on all values
+VECTORCALL VECMATH_FINLINE vec4f v_cvt_vec4f(vec4i a) {return v_cvti_vec4f(a);}
 
 //! unpacks 4 low/high unsigned shorts (in low 64 bits of vector, .xy) to 4 ints
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_lo_ush_vec4i(vec4i a);
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_hi_ush_vec4i(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_lo_ush_vec4i(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_hi_ush_vec4i(vec4i a);
 //! unpacks 4 low/high signed shorts (in low 64 bits of vector, .xy) to 4 ints
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_lo_ssh_vec4i(vec4i a);
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_hi_ssh_vec4i(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_lo_ssh_vec4i(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_hi_ssh_vec4i(vec4i a);
 //! unpacks 8 unsigned bytes (in low 64 bits of vector, .xy) to 4 shorts
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_byte_vec4i(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_byte_vec4i(vec4i a);
 
 //! converts float vector to 4 halfs and stores(unaligned)
-VECMATH_FINLINE void VECTORCALL v_float_to_half(uint16_t* __restrict m, const vec4f v);
+VECTORCALL VECMATH_FINLINE void v_float_to_half(uint16_t* __restrict m, const vec4f v);
 //! unpacks 4 halfs into float vector. handles denorms, do not handles infs and nans
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float(vec4i m);
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float(vec4i m);
 //! unpacks 4 halfs into float vector. handles denorms, infs and nans
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float_specials(vec4i m);
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float_specials(vec4i m);
 //! reads(unaligned) and unpacks 4 halfs into float vector
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float(const uint16_t* __restrict m);
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float(const uint16_t* __restrict m);
 //! reads(unaligned) and unpacks 4 halfs into float vector
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float_specials(const uint16_t* __restrict m);
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float_specials(const uint16_t* __restrict m);
 
 //! converts float vector to 4 halfs (lower 16 bits of vec4i), doesn't round correctly
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half(vec4f v);
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half(vec4f v);
 //handles infs/nans, doesn't round correctly
 //it (incorrectly) translates some of sNaNs into infinity, so be careful!
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_specials(vec4f f);
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_specials(vec4f f);
 
 // round-to-nearest-even, doesn't handle NANs
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_rtne(vec4f f);
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_rtne(vec4f f);
 //! not check for NANs, result halves are always bigger than source
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_up(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_up(vec4f a);
 //! not check for NANs, result halves are always smaller than source
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_down(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_down(vec4f a);
 
 //! pack float vector to 4 bytes with saturation
 VECMATH_FINLINE uint32_t v_float_to_byte ( vec4f x );
@@ -206,215 +206,217 @@ VECMATH_FINLINE uint32_t v_float_to_byte ( vec4f x );
 VECMATH_FINLINE vec4f v_byte_to_float ( uint32_t x );
 
 //! round to biggest integer (result remains fp)
-VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a);
 
 //! round to smallest integer (result remains fp)
-VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a);
 
 //! round to biggest integer (result remains int)
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a);
 
 //! round to smallest integer (result remains int)
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_floori(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_floori(vec4f a);
 
 //! round to nearest integer (result remains int)
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_roundi(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a);
 
 //! round to nearest integer (result remains fp)
-VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a);
 //! (a + b)
-VECMATH_FINLINE vec4f VECTORCALL v_add(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b);
 //! (a - b)
-VECMATH_FINLINE vec4f VECTORCALL v_sub(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b);
 //! (a * b)
-VECMATH_FINLINE vec4f VECTORCALL v_mul(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b);
 //! (a / b)
-VECMATH_FINLINE vec4f VECTORCALL v_div(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b);
 //! (a / b), fast/estimate version
-VECMATH_FINLINE vec4f VECTORCALL v_div_est(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_div_est(vec4f a, vec4f b);
 //! (a / b) if |b| > VERY_SMALL_NUMBER, else def value (component-wise)
-VECMATH_FINLINE vec4f VECTORCALL v_safediv(vec4f a, vec4f b, vec4f def = v_zero());
+VECTORCALL VECMATH_FINLINE vec4f v_safediv(vec4f a, vec4f b, vec4f def = v_zero());
 //! (a % b) (float)
-VECMATH_FINLINE vec4f VECTORCALL v_mod(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_mod(vec4f a, vec4f b);
 //! (a * b + c)
-VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c);
 //! (a * b - c)
-VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c);
 //! -(a * b - c) == c - a*b
-VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c);
 //! .x = (a.x + b.x)
-VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b);
 //! .x = (a.x - b.x)
-VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b);
 //! .x = (a.x * b.x)
-VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b);
 //! .x = (a.x / b.x)
-VECMATH_FINLINE vec4f VECTORCALL v_div_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b);
 //! .x = (a.x * b.x + c.x)
-VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c);
 //! .x = (a.x * b.x - c.x)
-VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c);
 //! 1/a, fast estimate
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est(vec4f a);
 //! 1/a
-VECMATH_FINLINE vec4f VECTORCALL v_rcp(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rcp(vec4f a);
 //! .x = 1/a.x, fast estimate
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a);
 //! .x = 1/a.x
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_x(vec4f a);
 //! 1/a if |a|>VERY_SMALL_NUMBER, else def value (component-wise)
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_safe(vec4f a, vec4f def = v_zero());
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_safe(vec4f a, vec4f def = v_zero());
 //! (a * a)
-VECMATH_FINLINE vec4f VECTORCALL v_sqr(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqr(vec4f a);
 //! .x = a.x*a.x
-VECMATH_FINLINE vec4f VECTORCALL v_sqr_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqr_x(vec4f a);
 //! min(a,b)
-VECMATH_FINLINE vec4f VECTORCALL v_min(vec4f a, vec4f b);
-VECMATH_FINLINE vec4i VECTORCALL v_mini(vec4i a, vec4i b);
-VECMATH_FINLINE vec4i VECTORCALL v_minu(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b);
 //! max(a,b)
-VECMATH_FINLINE vec4f VECTORCALL v_max(vec4f a, vec4f b);
-VECMATH_FINLINE vec4i VECTORCALL v_maxi(vec4i a, vec4i b);
-VECMATH_FINLINE vec4i VECTORCALL v_maxu(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b);
 //! -a
-VECMATH_FINLINE vec4f VECTORCALL v_neg(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_negi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_neg(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a);
 //! fabs(a)
-VECMATH_FINLINE vec4f VECTORCALL v_abs(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_absi(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a);
+//! check if /a can produce NaN's or inf
+VECTORCALL VECMATH_FINLINE vec4f v_is_unsafe_divisor(vec4f a);
 
 //! LERP a to b using parameter tttt
-VECMATH_FINLINE quat4f VECTORCALL v_lerp_vec4f(vec4f tttt, quat4f a, quat4f b);
+VECTORCALL VECMATH_FINLINE quat4f v_lerp_vec4f(vec4f tttt, quat4f a, quat4f b);
 
 //! (a + b)
-VECMATH_FINLINE vec4i VECTORCALL v_addi(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_addi(vec4i a, vec4i b);
 //! (a - b)
-VECMATH_FINLINE vec4i VECTORCALL v_subi(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_subi(vec4i a, vec4i b);
 //! (a * b), signed integers. result is only correctly defined if both operands and result is within [-1<<31, 1<<31) range
-VECMATH_FINLINE vec4i VECTORCALL v_muli(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b);
 
 //! shift left (unsigned integer). bits is immediate value
-VECMATH_FINLINE vec4i VECTORCALL v_slli(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_slli(vec4i v, int bits);
 //! shift right (unsigned integer). bits is immediate value
-VECMATH_FINLINE vec4i VECTORCALL v_srli(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srli(vec4i v, int bits);
 //! shift right (signed integer). bits is immediate value
-VECMATH_FINLINE vec4i VECTORCALL v_srai(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srai(vec4i v, int bits);
 //! shift left (unsigned integer). bits is variative value
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits);
 //! shift right (unsigned integer). bits is variative value
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits);
 //! shift right (signed integer). bits is variative value
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits);
 //! shift left (unsigned integer). bits is variative 64-bit value
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, vec4i bits);
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits);
 //! shift left (unsigned integer). bits is variative 64-bit value
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, vec4i bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits);
 //! shift right (signed integer). bits is variative 64-bit value
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, vec4i bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits);
 
 //! shift left (unsigned integer)
-VECMATH_FINLINE vec4i VECTORCALL v_sll(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_sll(vec4i v, int bits);
 //! shift right (unsigned integer)
-VECMATH_FINLINE vec4i VECTORCALL v_srl(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_srl(vec4i v, int bits);
 //! shift right (signed integer)
-VECMATH_FINLINE vec4i VECTORCALL v_sra(vec4i v, int bits);
+VECTORCALL VECMATH_FINLINE vec4i v_sra(vec4i v, int bits);
 
 //! a | b (bitwise, integer)
-VECMATH_FINLINE vec4i VECTORCALL v_ori(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_ori(vec4i a, vec4i b);
 //! a & b (bitwise, integer)
-VECMATH_FINLINE vec4i VECTORCALL v_andi(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_andi(vec4i a, vec4i b);
 //! a ^ b (bitwise, integer)
-VECMATH_FINLINE vec4i VECTORCALL v_xori(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_xori(vec4i a, vec4i b);
 
 //! .xyzw = x & y & z & w
-VECMATH_FINLINE vec4f VECTORCALL v_hand(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hand(vec4f a);
 //! .xyzw = x | y | z | w
-VECMATH_FINLINE vec4f VECTORCALL v_hor(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hor(vec4f a);
 //! .xyzw = x & y & z
-VECMATH_FINLINE vec4f VECTORCALL v_hand3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hand3(vec3f a);
 //! .xyzw = x | y | z
-VECMATH_FINLINE vec4f VECTORCALL v_hor3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hor3(vec3f a);
 //! .x = x + y + z + w
-VECMATH_FINLINE vec4f VECTORCALL v_hadd4_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a);
 //! .x = x + y + z
-VECMATH_FINLINE vec4f VECTORCALL v_hadd3_x(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec3f a);
 //! return min of .xyzw
-VECMATH_FINLINE vec4f VECTORCALL v_hmin(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a);
 //! return max of .xyzw
-VECMATH_FINLINE vec4f VECTORCALL v_hmax(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a);
 //! return min of .xyz
-VECMATH_FINLINE vec4f VECTORCALL v_hmin3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmin3(vec3f a);
 //! return max of .xyz
-VECMATH_FINLINE vec4f VECTORCALL v_hmax3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a);
 //! return x*y*z*w
-VECMATH_FINLINE vec4f VECTORCALL v_hmul(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmul(vec4f a);
 //! return x*y*z
-VECMATH_FINLINE vec4f VECTORCALL v_hmul3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec4f v_hmul3(vec3f a);
 
 //! 1/sqrt_est(a), fast estimate
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4_fast(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4_fast(vec4f a);
 //! 1/sqrt(a), Newton-Raphson refinement
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4(vec4f a);
 //! .x = 1/sqrt_est(a)
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_fast_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_fast_x(vec4f a);
 //! .x = 1/sqrt(a)
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a);
 
 //! sqrt_est(a), fast estimate
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4_fast(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a);
 //! sqrt(a), Newton-Raphson refinement
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4(vec4f a);
 //! .x = sqrt_est(a.x)
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_fast_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f a);
 //! .x = sqrt(a.x)
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f a);
 
 //! cyclic rotate
-VECMATH_FINLINE vec4f VECTORCALL v_rot_1(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_rot_2(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_rot_3(vec4f a);
-VECMATH_FINLINE vec4i VECTORCALL v_roti_1(vec4i a);
-VECMATH_FINLINE vec4i VECTORCALL v_roti_2(vec4i a);
-VECMATH_FINLINE vec4i VECTORCALL v_roti_3(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4f v_rot_1(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rot_2(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_rot_3(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a);
 
 //! permutations (mostly used in common implementation)
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzwx(vec4f a); //< alias for v_rot_1()
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwxy(vec4f a); //< alias for v_rot_2()
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wxyz(vec4f a); //< alias for v_rot_3()
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxw(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxyw(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzxz(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxyy(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zzww(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxzz(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yyww(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyxy(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxx(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxy(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywyw(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzz(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwx(vec4f a); //< alias for v_rot_1()
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwxy(vec4f a); //< alias for v_rot_2()
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wxyz(vec4f a); //< alias for v_rot_3()
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f a);
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzac(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywbd(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyab(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwcd(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xaxa(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yybb(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bbyx(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ayzw(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzw(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycw(vec4f xyzw, vec4f abcd);
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzd(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd);
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd);
 
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xzac(vec4i xyzw, vec4i abcd);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyab(vec4i xyzw, vec4i abcd);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xycd(vec4i xyzw, vec4i abcd);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xbzd(vec4i xyzw, vec4i abcd);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyzd(vec4i xyzw, vec4i abcd);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xzxz(vec4i xyzw);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_ywyw(vec4i xyzw);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyxy(vec4i xyzw);
-VECMATH_FINLINE vec4i VECTORCALL v_permi_zwzw(vec4i xyzw);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzac(vec4i xyzw, vec4i abcd);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyab(vec4i xyzw, vec4i abcd);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xycd(vec4i xyzw, vec4i abcd);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xbzd(vec4i xyzw, vec4i abcd);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyzd(vec4i xyzw, vec4i abcd);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzxz(vec4i xyzw);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_ywyw(vec4i xyzw);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyxy(vec4i xyzw);
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zwzw(vec4i xyzw);
 
 #define v_perm_xyXY v_perm_xyab
 #define v_perm_zwZW v_perm_zwcd
@@ -430,118 +432,118 @@ VECMATH_FINLINE vec4i VECTORCALL v_permi_zwzw(vec4i xyzw);
 
 
 //! pack 8x 32-bit ints into 8x 16-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a, vec4i b);
 //! pack 8x 32-bit ints (value being duplicated) into 8x 16-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a);
 //! pack 8x 32-bit ints into 8x unsigned 16-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a, vec4i b);
 //! pack 8x 32-bit ints (value being duplicated) into 8x unsigned 16-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a);
 //! pack 16x 16-bit ints into 16x unsigned 8-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a, vec4i b);
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a, vec4i b);
 //! pack 16x 16-bit ints into 16x unsigned 8-bit ints
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a);
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a);
 
 
 //
 // vector algebra
 //
 //! dot product: .xyzw = (a.x * b.x + a.y * b.y); a.z, b.z, a.w, b.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_dot2(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b);
 //! dot product: .xyzw = (a.x * b.x + a.y * b.y + a.z * b.z); a.w, b.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_dot3(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b);
 //! dot product: .xyzw = (a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w)
-VECMATH_FINLINE vec4f VECTORCALL v_dot4(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b);
 //! dot product: .x = (a.x * b.x + a.y * b.y); a.z, b.z, a.w, b.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_dot2_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b);
 //! dot product: .x = (a.x * b.x + a.y * b.y + a.z * b.z); a.w, b.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_dot3_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b);
 //! dot product: .x = (a.x * b.x + a.y * b.y + a.z * b.z + a.w * b.w)
-VECMATH_FINLINE vec4f VECTORCALL v_dot4_x(vec4f a, vec4f b);
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b);
 //! cross product: a x b; ; a.w,b.w could be anything, even NAN
-VECMATH_FINLINE vec3f VECTORCALL v_cross3(vec3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b);
 
 //! make plane from 3 points
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane(vec3f p0, vec3f p1, vec3f p2);
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane(vec3f p0, vec3f p1, vec3f p2);
 
 //! make plane from point and two dirs from point
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane_dir(vec3f p0, vec3f dir0, vec3f dir1);
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane_dir(vec3f p0, vec3f dir0, vec3f dir1);
 
 //! make plane from point and normal of the plane
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane_norm(vec3f p0, vec3f norm);
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane_norm(vec3f p0, vec3f norm);
 
 //! transform plane with matrix
-VECMATH_FINLINE plane3f VECTORCALL v_transform_plane(plane3f plane, mat44f_cref transform);
+VECTORCALL VECMATH_FINLINE plane3f v_transform_plane(plane3f plane, mat44f_cref transform);
 
 //! distance from point b to plane a: .xyzw = (a.x * b.x + a.y * b.y + a.z * b.z + a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist(plane3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b);
 
 //! distance from point b to plane a: .x = (a.x * b.x + a.y * b.y + a.z * b.z + a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist_x(plane3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b);
 
 //! scalar triple product: (a x b) * c = dot3(cross3(a, b), c)
-VECMATH_FINLINE vec3f VECTORCALL v_striple3(vec3f a, vec3f b, vec3f c);
+VECTORCALL VECMATH_FINLINE vec3f v_striple3(vec3f a, vec3f b, vec3f c);
 //! vector triple product: a x (b x c) = b(a*c) - c(a*b) = cross3(a, cross(b, c)
-VECMATH_FINLINE vec3f VECTORCALL v_vtriple3(vec3f a, vec3f b, vec3f c);
+VECTORCALL VECMATH_FINLINE vec3f v_vtriple3(vec3f a, vec3f b, vec3f c);
 
 //! length squared: .xyzw = a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a);
 //! length squared: .xyzw = a.x*a.x + a.y*a.y + a.z*a.z
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a);
 //! length squared: .xyzw = a.x*a.x + a.y*a.y
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a);
 
 //! length: .xyzw = sqrt_est(a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_length4_est(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est(vec4f a);
 //! estimate length: .xyzw = sqrt_est(a.x*a.x + a.y*a.y + a.z*a.z)
-VECMATH_FINLINE vec3f VECTORCALL v_length3_est(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est(vec3f a);
 //! estimate length: .xyzw = sqrt_est(a.x*a.x + a.y*a.y)
-VECMATH_FINLINE vec4f VECTORCALL v_length2_est(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est(vec4f a);
 //! length: .xyzw = sqrt(a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_length4(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4(vec4f a);
 //! length: .xyzw = sqrt(a.x*a.x + a.y*a.y + a.z*a.z)
-VECMATH_FINLINE vec3f VECTORCALL v_length3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3(vec3f a);
 //! length: .xyzw = sqrt(a.x*a.x + a.y*a.y)
-VECMATH_FINLINE vec4f VECTORCALL v_length2(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2(vec4f a);
 //! length squared: .x = a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a);
 //! length squared: .x = a.x*a.x + a.y*a.y + a.z*a.z, a.w could be anything (even NAN)
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq_x(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a);
 //! length squared: .x = a.x*a.x + a.y*a.y, a.z, a.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a);
 
 //! estimate length: .x = sqrt_est(a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_length4_est_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est_x(vec4f a);
 //! estimate length: .x = sqrt_est(a.x*a.x + a.y*a.y + a.z*a.z), a.w could be anything (even NAN)
-VECMATH_FINLINE vec3f VECTORCALL v_length3_est_x(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est_x(vec3f a);
 //! estimate length: .x = sqrt_est(a.x*a.x + a.y*a.y, a.z, a.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_length2_est_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est_x(vec4f a);
 //! length: .x = sqrt(a.x*a.x + a.y*a.y + a.z*a.z + a.w*a.w)
-VECMATH_FINLINE vec4f VECTORCALL v_length4_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length4_x(vec4f a);
 //! length: .x = sqrt(a.x*a.x + a.y*a.y + a.z*a.z), a.w could be anything (even NAN)
-VECMATH_FINLINE vec3f VECTORCALL v_length3_x(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_length3_x(vec3f a);
 //! length: .x = sqrt(a.x*a.x + a.y*a.y), a.z, a.w could be anything (even NAN)
-VECMATH_FINLINE vec4f VECTORCALL v_length2_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_length2_x(vec4f a);
 
 //! normalize: a/length(a). will return NaN for zero vector
-VECMATH_FINLINE vec4f VECTORCALL v_norm4(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a);
 //! normalize: a/length(a), .w could be anything (even NAN). will return NaN for zero vector
-VECMATH_FINLINE vec3f VECTORCALL v_norm3(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_norm3(vec3f a);
 //! normalize: a/length(a), .z, .w could be anything (even NAN). will return NaN for zero vector
-VECMATH_FINLINE vec4f VECTORCALL v_norm2(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a);
 //! nans converted to zero, v_and(a, v_cmp_eq(a,a))
-VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_remove_nan(vec4f a);
 //! nans and infs converted to zero
-VECMATH_FINLINE vec4f VECTORCALL v_remove_not_finite(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_remove_not_finite(vec4f a);
 //! safe normalize: a/length(a)
 //! result is not guaranteed to be normalized, but is definetly not NaN (NAN components will be zero)
-VECMATH_FINLINE vec4f VECTORCALL v_norm4_safe(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm4_safe(vec4f a);
 //! safe normalize: a/length(a), .w could be anything (even NAN)
 //! result is not guaranteed to be normalized, but is definetly not NaN (NAN components will be zero)
-VECMATH_FINLINE vec3f VECTORCALL v_norm3_safe(vec3f a);
+VECTORCALL VECMATH_FINLINE vec3f v_norm3_safe(vec3f a);
 //! safe normalize: a/length(a), .z, .w could be anything (even NAN)
 //! result is not guaranteed to be normalized, but is definetly not NaN (NAN components will be zero)
-VECMATH_FINLINE vec4f VECTORCALL v_norm2_safe(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_norm2_safe(vec4f a);
 
 
 //
@@ -549,178 +551,178 @@ VECMATH_FINLINE vec4f VECTORCALL v_norm2_safe(vec4f a);
 //
 
 //! m * v,  matrix is treated column-major
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec4(mat44f_cref m, vec4f v);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v);
 //! m * v,  matrix is treated column-major, v.w=0
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3v(mat44f_cref m, vec3f v);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v);
 //! m * v,  matrix is treated column-major, v.w=1
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3p(mat44f_cref m, vec3f v);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v);
 //! m * v,  matrix is treated column-major
-VECMATH_FINLINE vec3f VECTORCALL v_mat33_mul_vec3(mat33f_cref m, vec3f v);
+VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v);
 //! m * v,  matrix is treated row-major, v.w=0
-VECMATH_FINLINE vec3f VECTORCALL v_mat43_mul_vec3v(mat43f_cref m, vec3f v);
+VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3v(mat43f_cref m, vec3f v);
 //! m * v,  matrix is treated row-major, v.w=1
-VECMATH_FINLINE vec3f VECTORCALL v_mat43_mul_vec3p(mat43f_cref m, vec3f v);
+VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3p(mat43f_cref m, vec3f v);
 
 //! transfrom position and apply max scale to radius
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_bsph(mat44f_cref m, vec4f bsph);
-VECMATH_FINLINE void VECTORCALL v_mat44_mul_bsph(mat44f_cref m, vec4f &bsph_pos, vec4f &bsph_rad_x);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_bsph(mat44f_cref m, vec4f bsph);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul_bsph(mat44f_cref m, vec4f &bsph_pos, vec4f &bsph_rad_x);
 
 //! q * v, rotate vector using normalized quaternion
-VECMATH_FINLINE vec3f VECTORCALL v_quat_mul_vec3(quat4f q, vec3f v);
+VECTORCALL VECMATH_FINLINE vec3f v_quat_mul_vec3(quat4f q, vec3f v);
 
 //! q1 * q2, effectively multiply rotations
-VECMATH_FINLINE quat4f VECTORCALL v_quat_mul_quat(quat4f q1, quat4f q2);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_mul_quat(quat4f q1, quat4f q2);
 
 //! compute conjugate quaternion
-VECMATH_FINLINE quat4f VECTORCALL v_quat_conjugate(quat4f q);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_conjugate(quat4f q);
 
 //
 // matrix algebra
 //
 
 //! identity matrix 4x4
-VECMATH_FINLINE void VECTORCALL v_mat44_ident(mat44f &dest);
+VECTORCALL VECMATH_FINLINE void v_mat44_ident(mat44f &dest);
 //! identity matrix 4x4 with swapped X and Z columns
-VECMATH_FINLINE void VECTORCALL v_mat44_ident_swapxz(mat44f &dest);
+VECTORCALL VECMATH_FINLINE void v_mat44_ident_swapxz(mat44f &dest);
 //! identity matrix 3x3
-VECMATH_FINLINE void VECTORCALL v_mat33_ident(mat33f &dest);
+VECTORCALL VECMATH_FINLINE void v_mat33_ident(mat33f &dest);
 //! identity matrix 4x4 with swapped X and Z columns
-VECMATH_FINLINE void VECTORCALL v_mat33_ident_swapxz(mat33f &dest);
+VECTORCALL VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest);
 
 //! make perspective matrix 4x4
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_reverse(mat44f &dest, float wk, float hk, float zn, float zf);//zn - 1, zf - 0
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_forward(mat44f &dest, float wk, float hk, float zn, float zf);//zn - 0, zf - 1
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp(mat44f &dest, float wk, float hk, float zn, float zf);// same as reverse
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp_reverse(mat44f &dest, float wk, float hk, float zn, float zf);//zn - 1, zf - 0
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp_forward(mat44f &dest, float wk, float hk, float zn, float zf);//zn - 0, zf - 1
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp(mat44f &dest, float wk, float hk, float zn, float zf);// same as reverse
 //! make view matrix 3x3 from look_dir
-VECMATH_FINLINE void VECTORCALL v_mat33_make_from_look(mat33f &dest, vec4f look_dir);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_from_look(mat33f &dest, vec4f look_dir);
 //! make view submatrix 3x3 of 4x3 from look_dir
-VECMATH_FINLINE void VECTORCALL v_mat44_make33_from_look(mat44f &dest, vec4f look_dir);
-VECMATH_FINLINE void VECTORCALL v_view_matrix_from_tangentZ(mat33f &dest, vec4f look_dir);
+VECTORCALL VECMATH_FINLINE void v_mat44_make33_from_look(mat44f &dest, vec4f look_dir);
+VECTORCALL VECMATH_FINLINE void v_view_matrix_from_tangentZ(mat33f &dest, vec4f look_dir);
 //! make view submatrix 3x3 of 4x3 from look_dir
-VECMATH_FINLINE void VECTORCALL v_mat44_make_look_at(mat44f &dest, vec4f eye, vec4f at, vec4f up);
+VECTORCALL VECMATH_FINLINE void v_mat44_make_look_at(mat44f &dest, vec4f eye, vec4f at, vec4f up);
 //! make orthogonal projection matrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_ortho(mat44f &dest, float w, float h, float zn, float zf);
+VECTORCALL VECMATH_FINLINE void v_mat44_make_ortho(mat44f &dest, float w, float h, float zn, float zf);
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around 'v' clockwise
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw(mat33f &dest, vec3f v, vec4f ang);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw(mat33f &dest, vec3f v, vec4f ang);
 //! make rotational matrix 3x3 to rotate 'ang' radians around X axis clockwise
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_x(mat33f &dest, vec4f ang);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_x(mat33f &dest, vec4f ang);
 //! make rotational matrix 3x3 to rotate 'ang' radians around Y axis clockwise
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_y(mat33f &dest, vec4f ang);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_y(mat33f &dest, vec4f ang);
 //! make rotational matrix 3x3 to rotate 'ang' radians around Z axis clockwise
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang);
 //! make composite matrix 3x3: =rot_z(ang.z)*rot_y(ang.y)*rot_x(ang.x)
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_xyz);
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_xyz);
 
 //! T(m), 4x4 -> 4x4
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(mat44f &dest, mat44f_cref src);
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3);
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3);
 //! T(m), 3x3 -> 3x3
-VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, vec3f src_col0, vec3f src_col1, vec3f src_col2);
-VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, mat33f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, vec3f src_col0, vec3f src_col1, vec3f src_col2);
+VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, mat33f_cref src);
 //! T(m), 4x4 -> 3x3, omitting last column. So we can make .w not zero
-//VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec4f col3);
+//VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec4f col3);
 
 //! T(m), 4x4 column major -> 4x3 row major
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src);
 //! T(m), 4x3 row major -> 4x4 column major
-VECMATH_FINLINE void VECTORCALL v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src);
+VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src);
 //! extract rotation/scale transformation from mat44 to mat33
-VECMATH_FINLINE void VECTORCALL v_mat33_from_mat44(mat33f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_from_mat44(mat33f &dest, mat44f_cref m);
 
 //! make 3x3 rotation matrix from quaternion
-VECMATH_FINLINE void VECTORCALL v_mat33_from_quat(mat33f &dest, quat4f q);
+VECTORCALL VECMATH_FINLINE void v_mat33_from_quat(mat33f &dest, quat4f q);
 //! make 4x4 matrix from quaternion and position
-VECMATH_FINLINE void VECTORCALL v_mat44_from_quat(mat44f &dest, quat4f q, vec4f pos);
+VECTORCALL VECMATH_FINLINE void v_mat44_from_quat(mat44f &dest, quat4f q, vec4f pos);
 //! compose 4x4 matrix from position/rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat44_compose(mat44f &dest, vec4f pos, quat4f rot, vec4f scale);
+VECTORCALL VECMATH_FINLINE void v_mat44_compose(mat44f &dest, vec4f pos, quat4f rot, vec4f scale);
 //! compose 3x3 matrix from rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat33_compose(mat33f &dest, quat4f rot, vec4f scale);
+VECTORCALL VECMATH_FINLINE void v_mat33_compose(mat33f &dest, quat4f rot, vec4f scale);
 
 //! decompose 3x3 matrix to rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat33_decompose(mat33f_cref tm, quat4f &rot, vec4f &scl);
+VECTORCALL VECMATH_FINLINE void v_mat33_decompose(mat33f_cref tm, quat4f &rot, vec4f &scl);
 //! decompose 4x4 matrix to position/rotation/scale (assuming ordinary matrix 4x3)
-VECMATH_FINLINE void VECTORCALL v_mat4_decompose(mat44f_cref tm, vec3f &pos, quat4f &rot, vec4f &scl);
+VECTORCALL VECMATH_FINLINE void v_mat4_decompose(mat44f_cref tm, vec3f &pos, quat4f &rot, vec4f &scl);
 
 //! m1+m2
-VECMATH_FINLINE void VECTORCALL v_mat44_add(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_add(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! m1+m2
-VECMATH_FINLINE void VECTORCALL v_mat33_add(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat33_add(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
 //! m1-m2
-VECMATH_FINLINE void VECTORCALL v_mat44_sub(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_sub(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! m1-m2
-VECMATH_FINLINE void VECTORCALL v_mat33_sub(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat33_sub(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
 //! -m
-VECMATH_FINLINE void VECTORCALL v_mat33_neg(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_neg(mat44f &dest, mat44f_cref m);
 //! -m
-VECMATH_FINLINE void VECTORCALL v_mat33_neg(mat33f &dest, mat33f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_neg(mat33f &dest, mat33f_cref m);
 //! per-elem multiply m1 and m2
-VECMATH_FINLINE void VECTORCALL v_mat44_mul_elem(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul_elem(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! per-elem multiply m1 and m2
-VECMATH_FINLINE void VECTORCALL v_mat33_mul_elem(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat33_mul_elem(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
 
 //! m1*m2
-VECMATH_FINLINE void VECTORCALL v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! m1*m2, assuming m2.col1.w=m2.col2.w=m2.col0.w=0, m2.col3=0,0,0,1
-VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! m1*m2, assuming m2.col1.w=m2.col2.w=m2.col0.w=0, m2.col3=0,0,0,1.
 //Faster, then v_mat44_mul43(dest, m1, v_mat43_transpose_to_mat44(m2));
-VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat43f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat43f_cref m2);
 //! m1*m2, taking only rotational matrix from m2
-VECMATH_FINLINE void VECTORCALL v_mat44_mul33r(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul33r(mat44f &dest, mat44f_cref m1, mat44f_cref m2);
 //! m1*m2, assuming m2 is pure rotational matrix 3x3
-VECMATH_FINLINE void VECTORCALL v_mat44_mul33(mat44f &dest, mat44f_cref m1, mat33f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat44_mul33(mat44f &dest, mat44f_cref m1, mat33f_cref m2);
 //! m1*m2
-VECMATH_FINLINE void VECTORCALL v_mat33_mul(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat33_mul(mat33f &dest, mat33f_cref m1, mat33f_cref m2);
 //! m1*m2, taking only rotational matrix from m2
-VECMATH_FINLINE void VECTORCALL v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat44f_cref m2);
+VECTORCALL VECMATH_FINLINE void v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat44f_cref m2);
 //! orthonormalize 3x3 part of 4x4 matrix
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormalize33(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormalize33(mat44f &dest, mat44f_cref m);
 //! orthonormalize 3x3 matrix
-VECMATH_FINLINE void VECTORCALL v_mat33_orthonormalize(mat33f &dest, mat33f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_orthonormalize(mat33f &dest, mat33f_cref m);
 //! 1/m
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m);
 //! 1/m, assuming col1.w=col2.w=col0.w=0, col3=0,0,0,1. Resulting matrix will not conform same assumption (i.e. it will be 43 matrix, not 44)!
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse43(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse43(mat44f &dest, mat44f_cref m);
 //! 1/m, assuming col1.w=col2.w=col0.w=0, col3=0,0,0,1. Resulting matrix is correct 4x4 matrix, col0.w = col1.w = col2.w = 0; col3.w = 1
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse43_to44(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse43_to44(mat44f &dest, mat44f_cref m);
 //! 1/m
-VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m);
 //! 1/m == T33(m), col3 = -T33(m)*col3, with m assumed being orthonormal 43 matrix (i.e. col0.w=col1.w=col2.w = 0; col3.w = 1). Resulting matrix will not be 44 matrix, having garbage in col3.w!
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m);
 //! 1/m == T33(m), col3 = -T33(m)*col3, with m assumed being orthonormal 43 matrix (i.e. col0.w=col1.w=col2.w = 0; col3.w = 1). Resulting matrix will be valid 44 matrix, with col3.w == 1.
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m);
 
 //! 1/m == T(m), with m being orthonormal
-VECMATH_FINLINE void VECTORCALL v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m);
+VECTORCALL VECMATH_FINLINE void v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m);
 
 //! Determinant(m)
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_det(mat44f_cref m);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m);
 //! Determinant(m), assuming col1.w=col2.w=col0.w=0, col3=0,0,0,1
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_det43(mat44f_cref m);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det43(mat44f_cref m);
 //! Determinant(m)
-VECMATH_FINLINE vec4f VECTORCALL v_mat33_det(mat33f_cref m);
+VECTORCALL VECMATH_FINLINE vec4f v_mat33_det(mat33f_cref m);
 //! Calculate maximum scale of 3 axes
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43_sq(mat44f_cref tm);
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43(mat44f_cref tm);
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43_x(mat44f_cref tm);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_sq(mat44f_cref tm);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43(mat44f_cref tm);
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_x(mat44f_cref tm);
 //! .xyz = scales of 3 axes
-VECMATH_FINLINE vec3f VECTORCALL v_mat44_scale43_sq(mat44f_cref tm);
+VECTORCALL VECMATH_FINLINE vec3f v_mat44_scale43_sq(mat44f_cref tm);
 
 //! stores mat44f to aligned TMatrix from mat44f
-VECMATH_FINLINE void VECTORCALL v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm);
+VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm);
 
 //! stores mat44f to unaligned TMatrix
-VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm);
+VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm);
 
 //! mat44f from unaligned TMatrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43);
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43);
 
 //! mat44f from unaligned TMatrix but don't set row3 to {0,0,0,1} (will be undefined)
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43);
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43);
 
 //! mat44f from memaligned TMatrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43);
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43);
 
 
 //
@@ -728,81 +730,81 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float 
 //
 
 //! init as empty
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_empty(bbox3f &b);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_empty(bbox3f &b);
 //! init as ident (+-0.5 each coord)
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_ident(bbox3f &b);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_ident(bbox3f &b);
 //! init with point
-VECMATH_FINLINE void VECTORCALL v_bbox3_init(bbox3f &b, vec3f p);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, vec3f p);
 //! init with bb2 transformed with 4x4 matrix m
-VECMATH_FINLINE void VECTORCALL v_bbox3_init(bbox3f &b, mat44f_cref m, bbox3f bb2);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, mat44f_cref m, bbox3f bb2);
 //! init with bsph
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_bsph(bbox3f &b, vec3f bsph_center, vec3f bsph_radius);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_bsph(bbox3f &b, vec3f bsph_center, vec3f bsph_radius);
 //! init with ray
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len);
 //! init with segment
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_segment(bbox3f &b, vec4f from, vec4f to);
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_segment(bbox3f &b, vec4f from, vec4f to);
 
 //! extend bbox to enclose point
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_pt(bbox3f &b, vec3f p);
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_pt(bbox3f &b, vec3f p);
 //! extend bbox to enclose bb2
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_box(bbox3f &b, bbox3f b2);
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_box(bbox3f &b, bbox3f b2);
 //! extend bbox to enclose bb2 transformed with 4x4 matrix m
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_transformed_box(bbox3f &b, mat44f_cref m, bbox3f b2);
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_transformed_box(bbox3f &b, mat44f_cref m, bbox3f b2);
 //! extend bbox to enclose ray
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len);
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len);
 //! return b1+b2
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sum(bbox3f b1, bbox3f b2);
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_sum(bbox3f b1, bbox3f b2);
 //! return c ? b2 : b1 component-wise
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sel(bbox3f b1, bbox3f b2, vec4f c);
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_sel(bbox3f b1, bbox3f b2, vec4f c);
 
 //! .xyz = bbox dimensions; for empty bbox dimensions will be invalid (negative)
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_size(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_size(bbox3f b);
 //! .xyzw = bbox max dimension
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_max_size(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_max_size(bbox3f b);
 //! scale bbox by size_factor
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_scale(bbox3f b, vec4f size_factor);
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_scale(bbox3f b, vec4f size_factor);
 //! .xyz = bbox center
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_center(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_center(bbox3f b);
 // get bbox vertex by index [0;7]
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_point(bbox3f b, int idx);
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_point(bbox3f b, int idx);
 //! .x = radius of outer sphere
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_outer_rad(bbox3f b);
 //! .x = radius of inner sphere
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_inner_rad(bbox3f b);
 //! .x = diameter of inner sphere
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_diameter(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_inner_diameter(bbox3f b);
 //! .x = radius of outer sphere from zero coords
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad_from_zero(bbox3f b);
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_outer_rad_from_zero(bbox3f b);
 
 //! tests whether point is inside box and returns boolean (0 or non-0)
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_pt_inside(bbox3f b, vec3f p);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_pt_inside(bbox3f b, vec3f p);
 //! tests whether point is inside box xz and returns boolean (0 or non-0)
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_pt_inside_xz(bbox3f b, vec3f p);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_pt_inside_xz(bbox3f b, vec3f p);
 //! tests whether box b2 is fully inside box and returns boolean
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_inside(bbox3f b1, bbox3f b2);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_inside(bbox3f b1, bbox3f b2);
 //! tests whether boxes intersect and returns boolean (0 or non-0). if one box is whole world, and the other is inverse full (empty) - returns non-intersection
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_intersect(bbox3f b1, bbox3f b2);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect(bbox3f b1, bbox3f b2);
 
 //! tests whether boxes intersect and returns boolean (0 or non-0). safe for above case
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_intersect_safe(bbox3f b1, bbox3f b2);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect_safe(bbox3f b1, bbox3f b2);
 
 //! tests OBB box1 edges intersect planes of AABB box0 and returns boolean (0 or non-0).
-inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1);
+VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1);
 
 //! tests whether OBB box0 and OBB box1 intersect and returns boolean (0 or non-0).
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1);
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
                                                                       vec4f size_factor);
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
                                                                              bbox3f box1, const mat44f& b1_to_b0);
 //! get box = box0 & box1
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1);
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1);
 //! tests whether box intersecs sphere and returns boolean
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_sph_intersect(bbox3f box, vec4f bsph_center, vec4f bsph_r2_x);
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_sph_intersect(bbox3f box, vec4f bsph_center, vec4f bsph_r2_x);
 //! extend box in all 3 dimensions by ext
-VECMATH_FINLINE void VECTORCALL v_bbox3_extend(bbox3f &b, vec3f ext);
+VECTORCALL VECMATH_FINLINE void v_bbox3_extend(bbox3f &b, vec3f ext);
 //! extend 2d box component-wise by ext
-VECMATH_FINLINE vec4f VECTORCALL v_bbox2_extend(vec4f box2d, vec4f ext);
+VECTORCALL VECMATH_FINLINE vec4f v_bbox2_extend(vec4f box2d, vec4f ext);
 
 //! create empty bounding sphere (radius < 0)
 VECMATH_FINLINE void v_bsph_init_empty(vec4f &sph);
@@ -849,56 +851,56 @@ VECMATH_FINLINE void v_bsph_add_bsph_unsafe(vec4f& a, vec4f b);
 VECMATH_FINLINE void v_bsph_add_bbox_unsafe(vec4f& sph, bbox3f b);
 
 //! .x = squared MINIMUM distance from point c to bbox (bmin, bmax)
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c);
 
 //! .x = squared MINIMUM 2d (xz) distance from point c to bbox (bmin, bmax)
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_to_bbox_2d_x(vec4f bmin, vec4f bmax, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_to_bbox_2d_x(vec4f bmin, vec4f bmax, vec4f c);
 
 //! .x = squared MAXIMUM 3d distance from point c to bbox (bmin, bmax)
-VECMATH_FINLINE vec4f VECTORCALL v_max_dist_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c);
+VECTORCALL VECMATH_FINLINE vec4f v_max_dist_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c);
 
 //! .x = squared MINIMUM 3d distance from between two bbox
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_box_to_box_x(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB);
 
 //! .x = squared MINIMUM 3d distance from between two bbox
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_box_to_box_x_scaled(vec3f cA, vec3f extentA, vec3f cB, vec3f extentB, vec3f axis_scale);
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x_scaled(vec3f cA, vec3f extentA, vec3f cB, vec3f extentB, vec3f axis_scale);
 
 //returns point on infinite line which is closes to point
-VECMATH_FINLINE vec3f VECTORCALL closest_point_on_line(vec3f point, vec3f a, vec3f dir);
+VECTORCALL VECMATH_FINLINE vec3f closest_point_on_line(vec3f point, vec3f a, vec3f dir);
 //returns point on segment which is closes to point
-VECMATH_FINLINE vec3f VECTORCALL closest_point_on_segment(vec3f point, vec3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec3f closest_point_on_segment(vec3f point, vec3f a, vec3f b);
 //distance to line in x component
-VECMATH_FINLINE vec4f VECTORCALL distance_to_line_x(vec3f point, vec3f a, vec3f dir);
+VECTORCALL VECMATH_FINLINE vec4f distance_to_line_x(vec3f point, vec3f a, vec3f dir);
 //distance to segment in x component
-VECMATH_FINLINE vec4f VECTORCALL distance_to_seg_x(vec3f point, vec3f a, vec3f b);
+VECTORCALL VECMATH_FINLINE vec4f distance_to_seg_x(vec3f point, vec3f a, vec3f b);
 //get closest to c bbox point. return c, if c is inside bbox. undefined for empty boxes
-VECMATH_FINLINE vec3f VECTORCALL v_closest_bbox_point(vec3f bmin, vec3f bmax, vec3f c);
+VECTORCALL VECMATH_FINLINE vec3f v_closest_bbox_point(vec3f bmin, vec3f bmax, vec3f c);
 
 //returns 1 if segment with start, start + dir*tmax intersects box
-VECMATH_INLINE bool VECTORCALL v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
+VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
 //same as previous but without support of empty bboxes
-VECMATH_INLINE bool VECTORCALL v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
+VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box);
 //returns 1 if segment with start, start + dir*tmax intersects box, tmax will contain distance along ray
-VECMATH_INLINE bool VECTORCALL v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
+VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
 //same as previous but without support of empty bboxes
-VECMATH_INLINE bool VECTORCALL v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
+VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box);
 //returns 1 if segment with start, start + end intersects box
-VECMATH_FINLINE bool VECTORCALL v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f box);
+VECTORCALL VECMATH_FINLINE bool v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f box);
 
 //returns distance to box intersection
 //.x - closest dist (tmin), .y farthest dist (tmax)
 // both can be negative
 // ray intersects box if tmax >= max(ray.tmin, tmin) && tmin <= ray.tmax
-VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
+VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
 //approximate distance to box intersection (uses v_rcp_est instead of 1/rayDir). A bit faster, v_rcp_est error is < 1e-12
-VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist_est(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
+VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist_est(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box);
 
 // return -1 if no intersection found, or box side index in [0; 5] and output param 'at' in range [0.0; 1.0]
-inline int VECTORCALL v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at);
+VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at);
 
 // check ray or segment intersection with sphere
-VECMATH_FINLINE bool VECTORCALL v_test_ray_sphere_intersection(vec3f p0, vec3f dir, vec4f len, vec4f sphere_center, vec4f sphere_r2_x);
-VECMATH_FINLINE bool VECTORCALL v_test_segment_sphere_intersection(vec3f p0, vec3f p1, vec3f sphere_center, vec4f sphere_r2_x);
+VECTORCALL VECMATH_FINLINE bool v_test_ray_sphere_intersection(vec3f p0, vec3f dir, vec4f len, vec4f sphere_center, vec4f sphere_r2_x);
+VECTORCALL VECMATH_FINLINE bool v_test_segment_sphere_intersection(vec3f p0, vec3f p1, vec3f sphere_center, vec4f sphere_r2_x);
 
 // return two intersection distances if ray intersect sphere. both distances can be negative.
 VECMATH_FINLINE bool v_ray_sphere_intersection_dist(vec3f start, vec3f dir, vec3f sphere_center, vec4f sphere_r2_x, vec4f &out_p1_t, vec4f &out_p2_t);
@@ -907,21 +909,21 @@ VECMATH_FINLINE bool v_ray_sphere_intersection(vec3f start, vec3f dir, vec4f &t_
 
 //visibility
 ///construct 6 planes from worldviewproj matrix, with reversed z-buffer camPlanes5 far, camPlanes4 near
-VECMATH_FINLINE void VECTORCALL v_construct_camplanes(mat44f_cref clip,
+VECTORCALL VECMATH_FINLINE void v_construct_camplanes(mat44f_cref clip,
   vec4f &camPlanes0, vec4f &camPlanes1, vec4f &camPlanes2, vec4f &camPlanes3, vec4f &camPlanes4, vec4f &camPlanes5);
 
 //v_frustum_box. assume it has correct frustum planes intersection.
-VECMATH_FINLINE void VECTORCALL v_frustum_box_unsafe(bbox3f& box,
+VECTORCALL VECMATH_FINLINE void v_frustum_box_unsafe(bbox3f& box,
                                  vec4f camPlanes0, vec4f camPlanes1, vec4f camPlanes2,
                                  const vec4f &camPlanes3, const vec4f &camPlanes4, const vec4f &camPlanes5);
 
 //0,1,2 returns if sphere is outside (0), inisde(1), intersect(2) frustum, accepts 4 transponed planes and two others in regular
-VECMATH_FINLINE int VECTORCALL v_sphere_intersect(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
                   vec3f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane4, const vec4f& plane5);
 
 //0,1 returns if sphere is visible in frustum, accepts 4 transponed planes and two others in regular
-VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane4, const vec4f& plane5);
 
@@ -929,20 +931,20 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
 ///return zero if not visible. nonzero, otherwise
 // center and extent should be multiplied by 2.
 // it is fastest implementation
-VECMATH_FINLINE int VECTORCALL v_is_visible_extent_fast(vec3f center, vec3f extent, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast(vec3f center, vec3f extent, mat44f_cref clip);
 
 // same as above (and will call v_is_visible_extent_fast), but accepts bbox)
-VECMATH_FINLINE int VECTORCALL v_is_visible_b_fast(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_is_visible_b_fast(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 ///universal visibility function (accepts worldviewproj matrix)
 ///return zero if not visible in frustum or if unclamped bbox screen size is smaller, than threshold. not zero, otherwise
 // also, out screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
-VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip);
 
 /// same as previous but return w min, w max
 /// return zero if not visible in frustum or if bbox screen size is smaller, than threshold. 1, if all vertex are in front of near plane, -1 (and fullscreen rect) otherwise
 /// also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1), minmax_w is wWwW (minw, maxw, minw, maxw)
-VECMATH_FINLINE int VECTORCALL
+VECTORCALL VECMATH_FINLINE int
 v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip);
 
 
@@ -951,51 +953,51 @@ v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4
 ///it is slower than v_is_visible_b_fast, so do not call it if you don't know what are you doing
 ///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
 ///or use v_is_visible_b (it is faster on SSE)
-VECMATH_FINLINE vec4f VECTORCALL v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 
 ///for branching: (~v_test_vec_x_eqi_0( v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
-VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip);
+VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip);
 
 //! returns triangle vs sphere intersection
 // last parameter is squared radius!
-VECMATH_INLINE int VECTORCALL v_test_triangle_sphere_intersection(vec3f A, vec3f B, vec3f C, vec4f sph_c, vec4f sph_r2);
+VECTORCALL VECMATH_INLINE  int v_test_triangle_sphere_intersection(vec3f A, vec3f B, vec3f C, vec4f sph_c, vec4f sph_r2);
 
 //! gets perfect triangle bounding sphere center.
 // Warning - can work incorrectly on degenerative triangles (can produce nans)
-VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& p1, const vec3f& p2, const vec3f& p3 );
+VECTORCALL VECMATH_INLINE  vec3f v_triangle_bounding_sphere_center( const vec3f& p1, const vec3f& p2, const vec3f& p3 );
 
 // check is point p inside triangle with vertices t1,t2,t3 in 2D space
-VECMATH_INLINE bool VECTORCALL v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3);
+VECTORCALL VECMATH_INLINE  bool v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3);
 
 //
 // Quaternion math
 //
 
-//! make (unnormalized) quaternion from 3x3 rotation matrix
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat3(mat33f_cref m);
-//! make (unnormalized) quaternion from rotation part of 4x4 matrix
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat4(mat44f_cref m);
-//! make (unnormalized) quaternion from rotation part of 4x4 matrix
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat(vec3f col0, vec3f col1, vec3f col2);
+//! make quaternion from 3 normalized columns of 3x3 rotation matrix
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f col2);
+//! make quaternion from 3x3 rotation matrix (should be not scaled)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat33(mat33f_cref m);
+//! make quaternion from rotation part of 4x4 matrix (should be not scaled)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat43(mat44f_cref m);
 
 //! make (unnormalized) quaternion to rotate 'ang' radians around normalized 'v';
-inline quat4f VECTORCALL v_quat_from_unit_vec_ang(vec3f v, vec4f ang);
+VECTORCALL inline quat4f v_quat_from_unit_vec_ang(vec3f v, vec4f ang);
 //! make (unnormalized) quaternion to rotate 'v0' to 'v1'; both 'v0' and 'v1' must be normalized
-VECMATH_FINLINE quat4f VECTORCALL v_quat_from_unit_arc(vec3f v0, vec3f v1);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_unit_arc(vec3f v0, vec3f v1);
 //! make (unnormalized) quaternion to rotate 'v0' to 'v1', both CAN be not normalized
-VECMATH_FINLINE quat4f VECTORCALL v_quat_from_arc(vec3f v0, vec3f v1);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_arc(vec3f v0, vec3f v1);
 //! make (unnormalized) quaternion from heading, attitude, bank angles in .xyz
-inline quat4f VECTORCALL v_quat_from_euler(vec3f angles);
-//! make heading, attitude, bank angles from (unnormalized) quaternion
-inline vec3f VECTORCALL v_euler_from_un_quat(quat4f quat);
+VECTORCALL inline quat4f v_quat_from_euler(vec3f angles);
+//! make heading, attitude, bank angles from quaternion
+VECTORCALL inline vec3f v_euler_from_quat(quat4f quat);
 
 //! linear interpolation between normalized quaternions using parameter tttt
-VECMATH_FINLINE quat4f VECTORCALL v_quat_lerp(vec4f tttt, quat4f a, quat4f b);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_lerp(vec4f tttt, quat4f a, quat4f b);
 //! fast quasi-spherical linear interpolation between normalized quaternions
-VECMATH_FINLINE quat4f VECTORCALL v_quat_qslerp(float t, quat4f a, quat4f b);
+VECTORCALL VECMATH_FINLINE quat4f v_quat_qslerp(float t, quat4f a, quat4f b);
 //! fast quasi-spherical quadrangle interpolation between normalized quaternions
-VECMATH_FINLINE quat4f VECTORCALL v_quat_qsquad(float t,
+VECTORCALL VECMATH_FINLINE quat4f v_quat_qsquad(float t,
   const quat4f &q0, const quat4f &q1, const quat4f &q2, const quat4f &q3);
 
 //
@@ -1003,122 +1005,122 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_qsquad(float t,
 //
 
 //! compute sine and cosine for all components: for C={xyzw}  s.C = sin(a.C); c.C = cos(a.C);
-VECMATH_FINLINE void VECTORCALL v_sincos4(vec4f a, vec4f& s, vec4f& c);
+VECTORCALL VECMATH_FINLINE void v_sincos4(vec4f a, vec4f& s, vec4f& c);
 
 //! compute sine and cosine for .x: s.x = sin(a.x); c.x = cos(a.x);
-VECMATH_FINLINE void VECTORCALL v_sincos_x(vec4f a, vec4f& s, vec4f& c);
+VECTORCALL VECMATH_FINLINE void v_sincos_x(vec4f a, vec4f& s, vec4f& c);
 
 //! compute sine, cosine, tangent or arc for all components
-VECMATH_FINLINE vec4f VECTORCALL v_sin(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_cos(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_tan(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_asin(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_acos(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_atan(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_atan2(vec4f x, vec4f y);
+VECTORCALL VECMATH_FINLINE vec4f v_sin(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_cos(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_tan(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_asin(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_acos(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_atan(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_atan2(vec4f x, vec4f y);
 
 //! compute sine, cosine, tangent or arc for .x component
-VECMATH_FINLINE vec4f VECTORCALL v_sin_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_cos_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_tan_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_asin_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_acos_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_atan_x(vec4f a);
-VECMATH_FINLINE vec4f VECTORCALL v_atan2_x(vec4f x, vec4f y);
+VECTORCALL VECMATH_FINLINE vec4f v_sin_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_cos_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_tan_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_asin_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_acos_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_atan_x(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f v_atan2_x(vec4f x, vec4f y);
 
 // compute approximate atan |error| is < 0.00045
-VECMATH_FINLINE vec4f VECTORCALL v_atan_est(vec4f x);  // any x
+VECTORCALL VECMATH_FINLINE vec4f v_atan_est(vec4f x);  // any x
 
 // compute approximate atan2 |error| is < 0.0004
 // ~40% faster then v_atan2
 // NOTE: does not handle any of the following inputs:
 // (+0, +0), (+0, -0), (-0, +0), (-0, -0)
-VECMATH_INLINE vec4f VECTORCALL v_atan2_est(vec4f y, vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_atan2_est(vec4f y, vec4f x);
 
 //exp,log, pow
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p2(vec4f x);//polynom of 2
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p3(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p4(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p5(vec4f x);//polynom of 5
-VECMATH_INLINE vec4f VECTORCALL v_log2_est(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p2(vec4f x);//polynom of 2
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p3(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p4(vec4f x);
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p5(vec4f x);//polynom of 5
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p2(vec4f x);//polynom of 2
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p3(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p4(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p5(vec4f x);//polynom of 5
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p2(vec4f x);//polynom of 2
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p3(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p4(vec4f x);
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p5(vec4f x);//polynom of 5
 
-VECMATH_FINLINE vec4f VECTORCALL v_pow_est(vec4f x, vec4f y);////exp_polynom_of_4(log_polynom_of_5(x)*y)
+VECTORCALL VECMATH_FINLINE vec4f v_pow_est(vec4f x, vec4f y);////exp_polynom_of_4(log_polynom_of_5(x)*y)
 //
 // vector -> scalar transformation (often incurs penalty!)
 //
 
 //! extracts fp32 x-component of float[4]
-VECMATH_FINLINE float VECTORCALL v_extract_x(vec4f v);
+VECTORCALL VECMATH_FINLINE float v_extract_x(vec4f v);
 //! extracts fp32 y-component of float[4]
-VECMATH_FINLINE float VECTORCALL v_extract_y(vec4f v);
+VECTORCALL VECMATH_FINLINE float v_extract_y(vec4f v);
 //! extracts fp32 z-component of float[4]
-VECMATH_FINLINE float VECTORCALL v_extract_z(vec4f v);
+VECTORCALL VECMATH_FINLINE float v_extract_z(vec4f v);
 //! extracts fp32 w-component of float[4]
-VECMATH_FINLINE float VECTORCALL v_extract_w(vec4f v);
+VECTORCALL VECMATH_FINLINE float v_extract_w(vec4f v);
 
 //! extracts i16 x-component of short[8]
-VECMATH_FINLINE short VECTORCALL v_extract_xi16(vec4i v);
+VECTORCALL VECMATH_FINLINE short v_extract_xi16(vec4i v);
 
 //! extracts i64 x-component of i64[2]
-VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i a);
+VECTORCALL VECMATH_FINLINE int64_t v_extract_xi64(vec4i a);
 //! extracts i64 y-component of i64[2]
-VECMATH_FINLINE int64_t VECTORCALL v_extract_yi64(vec4i a);
+VECTORCALL VECMATH_FINLINE int64_t v_extract_yi64(vec4i a);
 
 //! extracts ith-component of short[8]
-VECMATH_FINLINE short VECTORCALL v_extract_i16(vec4i v, int i);
+VECTORCALL VECMATH_FINLINE short v_extract_i16(vec4i v, int i);
 
 //! extracts i32 x-component of int[4]
-VECMATH_FINLINE int VECTORCALL v_extract_xi(vec4i v);
+VECTORCALL VECMATH_FINLINE int v_extract_xi(vec4i v);
 //! extracts i32 y-component of int[4]
-VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v);
+VECTORCALL VECMATH_FINLINE int v_extract_yi(vec4i v);
 //! extracts i32 z-component of int[4]
-VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v);
+VECTORCALL VECMATH_FINLINE int v_extract_zi(vec4i v);
 //! extracts i32 w-component of int[4]
-VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v);
+VECTORCALL VECMATH_FINLINE int v_extract_wi(vec4i v);
 
 //! insert scalar to vector by index
-VECMATH_FINLINE vec4f VECTORCALL v_insert(float s, vec4f v, int i);
+VECTORCALL VECMATH_FINLINE vec4f v_insert(float s, vec4f v, int i);
 
 //! promote put scalar to specified place in vector; other elements undefined
-VECMATH_FINLINE vec4f VECTORCALL v_promote(float s, int i);
+VECTORCALL VECMATH_FINLINE vec4f v_promote(float s, int i);
 
 // sign extend
-VECMATH_FINLINE vec4f VECTORCALL is_neg_special(vec4f a);
+VECTORCALL VECMATH_FINLINE vec4f is_neg_special(vec4f a);
 
 //
 // support for slow but sometimes necessary branching
 //
 //! (int(v.x) == int(a.x)) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi(vec3f v, vec3f a);
 //! (int(v.x) == 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi_0(vec3f v);
 
 //! (v.x == a.x) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq(vec3f v, vec3f a);
 //! (v.x  > a.x) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt(vec3f v, vec3f a);
 //! (v.x >= a.x) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge(vec3f v, vec3f a);
 //! (v.x  < a.x) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt(vec3f v, vec3f a);
 //! (v.x <= a.x) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le(vec3f v, vec3f a);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le(vec3f v, vec3f a);
 
 //! (v.x == 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq_0(vec3f v);
 //! (v.x  > 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt_0(vec3f v);
 //! (v.x >= 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge_0(vec3f v);
 //! (v.x  < 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt_0(vec3f v);
 //! (v.x <= 0) ? 1 : 0
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le_0(vec3f v);
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le_0(vec3f v);
 
 
 #include "dag_vecMath_const.h"

--- a/dag_vecMathDecl.h
+++ b/dag_vecMathDecl.h
@@ -49,8 +49,10 @@ typedef const struct bsph3f& bsph3f_cref;
 #endif
 
 #ifndef VECTORCALL
-  //__vectorcall is faster on msvc, even on x64 target
-  #if (defined(_MSC_VER) || defined(__clang__)) && __SSE__
+  #if _TARGET_PC_MACOSX && __SSE__
+    #define VECTORCALL [[clang::vectorcall]]
+  #elif (defined(_MSC_VER) || defined(__clang__)) && __SSE__
+      //__vectorcall is faster on msvc, even on x64 target
     #define VECTORCALL __vectorcall
   #else
     #define VECTORCALL
@@ -130,8 +132,8 @@ struct mat44f
 {
   vec4f col0, col1, col2, col3;
 
-  VECMATH_FINLINE void VECTORCALL set33(mat33f_cref m) { col0 = m.col0; col1 = m.col1; col2 = m.col2; }
-  VECMATH_FINLINE void VECTORCALL set33(mat33f_cref m, vec4f c3)
+  VECTORCALL VECMATH_FINLINE void set33(mat33f_cref m) { col0 = m.col0; col1 = m.col1; col2 = m.col2; }
+  VECTORCALL VECMATH_FINLINE void set33(mat33f_cref m, vec4f c3)
     { col0 = m.col0; col1 = m.col1; col2 = m.col2; col3 = c3; }
 };
 

--- a/dag_vecMath_common.h
+++ b/dag_vecMath_common.h
@@ -45,39 +45,44 @@ NO_ASAN_INLINE vec4i v_ldui_p3(const int *m)
 NO_ASAN_INLINE vec3f v_ldu_p3_safe(const float *m) { return v_perm_xyab(v_ldu_half(m), v_ldu_x(m + 2)); }
 NO_ASAN_INLINE vec4i v_ldui_p3_safe(const int *m) { return v_permi_xyab(v_ldui_half(m), v_seti_x(m[2])); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f_mask(uint8_t bitmask)
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec4f_mask(uint8_t bitmask)
 {
   vec4i lookup = v_make_vec4i(1 << 0, 1 << 1, 1 << 2, 1 << 3);
   vec4i isolated = v_andi(v_splatsi(bitmask), lookup);
   return v_cast_vec4f(v_cmp_eqi(isolated, lookup));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_le(vec4f a, vec4f b) { return v_cmp_ge(b, a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_lt(vec4f a, vec4f b) { return v_cmp_gt(b, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_le(vec4f a, vec4f b) { return v_cmp_ge(b, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_lt(vec4f a, vec4f b) { return v_cmp_gt(b, a); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_clamp(vec4f t, vec4f min_val, vec4f max_val)
+VECTORCALL VECMATH_FINLINE vec4f v_clamp(vec4f t, vec4f min_val, vec4f max_val)
 {
   return v_max(v_min(t, max_val), min_val);
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_clampi(vec4i t, vec4i min_val, vec4i max_val)
+VECTORCALL VECMATH_FINLINE vec4i v_clampi(vec4i t, vec4i min_val, vec4i max_val)
 {
   return v_maxi(v_mini(t, max_val), min_val);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_safediv(vec4f a, vec4f b, vec4f def)
+VECTORCALL VECMATH_FINLINE vec4f v_is_unsafe_divisor(vec4f a)
 {
-  vec4f isDiv0 = v_cmp_lt(v_abs(b), V_C_VERY_SMALL_VAL);
+  return v_cmp_lt(v_abs(a), V_C_VERY_SMALL_VAL);
+}
+
+VECTORCALL VECMATH_FINLINE vec4f v_safediv(vec4f a, vec4f b, vec4f def)
+{
+  vec4f isDiv0 = v_is_unsafe_divisor(b);
   return v_sel(v_div(a, b), def, isDiv0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_safe(vec4f a, vec4f def)
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_safe(vec4f a, vec4f def)
 {
-  vec4f isDiv0 = v_cmp_lt(v_abs(a), V_C_VERY_SMALL_VAL);
+  vec4f isDiv0 = v_is_unsafe_divisor(a);
   return v_sel(v_rcp(a), def, isDiv0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mod(vec4f a, vec4f aDiv)
+VECTORCALL VECMATH_FINLINE vec4f v_mod(vec4f a, vec4f aDiv)
 {
   vec4f c = v_div(a, aDiv);
   vec4f cTrunc = v_cvt_vec4f(v_cvt_vec4i(c));
@@ -86,129 +91,129 @@ VECMATH_FINLINE vec4f VECTORCALL v_mod(vec4f a, vec4f aDiv)
   return r;
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_lerp_vec4f(vec4f tttt, quat4f a, quat4f b)
+VECTORCALL VECMATH_FINLINE quat4f v_lerp_vec4f(vec4f tttt, quat4f a, quat4f b)
 {
   return v_madd(v_sub(b, a), tttt, a);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_hand(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hand(vec4f a)
 {
   a = v_and(a, v_rot_1(a));
   return v_and(a, v_rot_2(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hor(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hor(vec4f a)
 {
   a = v_or(a, v_rot_1(a));
   return v_or(a, v_rot_2(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hand3(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hand3(vec3f a)
 {
   return v_and(v_splat_x(a), v_and(v_splat_y(a), v_splat_z(a)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hor3(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hor3(vec3f a)
 {
   return v_or(v_splat_x(a), v_or(v_splat_y(a), v_splat_z(a)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_hmin(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmin(vec4f a)
 {
   a = v_min(a, v_rot_1(a));
   return v_min(a, v_rot_2(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hmax(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmax(vec4f a)
 {
   a = v_max(a, v_rot_1(a));
   return v_max(a, v_rot_2(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hmin3(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmin3(vec3f a)
 {
   return v_min(v_splat_x(a), v_min(v_splat_y(a), v_splat_z(a)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hmax3(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmax3(vec3f a)
 {
   return v_max(v_splat_x(a), v_max(v_splat_y(a), v_splat_z(a)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hmul(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmul(vec4f a)
 {
   a = v_mul(a, v_rot_1(a));
   return v_mul(a, v_rot_2(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hmul3(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hmul3(vec3f a)
 {
   return v_mul(v_splat_x(a), v_mul(v_splat_y(a), v_splat_z(a)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_sqr(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqr(vec4f a)
 {
   return v_mul(a, a);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_sqr_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqr_x(vec4f a)
 {
   return v_mul_x(a, a);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxxx(vec4f a) { return v_splat_x(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yyyy(vec4f a) { return v_splat_y(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zzzz(vec4f a) { return v_splat_z(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wwww(vec4f a) { return v_splat_w(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzwx(vec4f a) { return v_rot_1(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwxy(vec4f a) { return v_rot_2(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wxyz(vec4f a) { return v_rot_3(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxxx(vec4f a) { return v_splat_x(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyyy(vec4f a) { return v_splat_y(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzzz(vec4f a) { return v_splat_z(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwww(vec4f a) { return v_splat_w(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzwx(vec4f a) { return v_rot_1(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwxy(vec4f a) { return v_rot_2(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wxyz(vec4f a) { return v_rot_3(a); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zcwd(vec4f xyzw, vec4f abcd) { return v_merge_lw(xyzw, abcd); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xayb(vec4f xyzw, vec4f abcd) { return v_merge_hw(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zcwd(vec4f xyzw, vec4f abcd) { return v_merge_lw(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xayb(vec4f xyzw, vec4f abcd) { return v_merge_hw(xyzw, abcd); }
 
 #if _TARGET_SIMD_VMX
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XYCX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzya(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZYA); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xaxa(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XAXA); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbcx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XBCX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XBZX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzac(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZAC); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzbx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZBX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxxc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YXXC); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxba(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YXBA); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywbd(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YWBD); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yaxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YAXX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ycxy(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YCXY); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxxb(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZXXB); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwba(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZWBA); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zayx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZAYX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zbwa(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZBWA); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wzdc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_WZDC); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bzxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_BZXX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bbyx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_BBYX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_caxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_CAXX); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_cxyc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_CXYC); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzxz(vec4f xyzw) { return V_PERM(xyzw, xyzw, V_PERM_XZAC); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XYCX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZYA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XAXA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbcx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XBCX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XBZX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZAC); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_XZBX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YXXC); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxba(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YXBA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YWBD); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YAXX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ycxy(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_YCXY); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZXXB); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwba(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZWBA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZAYX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zbwa(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_ZBWA); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wzdc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_WZDC); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_BZXX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_BBYX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_CAXX); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_cxyc(vec4f xyzw, vec4f abcd) { return V_PERM(xyzw, abcd, V_PERM_CXYC); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f xyzw) { return V_PERM(xyzw, xyzw, V_PERM_XZAC); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wabc(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, abcd, 3); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwab(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, abcd, 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxaa(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_x(xyzw), v_splat_x(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yybb(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_y(xyzw), v_splat_y(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wwdd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_w(xyzw), v_splat_w(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyab(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(xyzw), abcd, 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwcd(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, v_rot_2(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wabc(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, abcd, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwab(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxaa(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_x(xyzw), v_splat_x(abcd), 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_y(xyzw), v_splat_y(abcd), 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwdd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_w(xyzw), v_splat_w(abcd), 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(xyzw), abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd) { return V_SHIFT(xyzw, v_rot_2(abcd), 2); }
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_ayzw(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_x(abcd), v_rot_1(xyzw), 3); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xbzw(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_merge_hw(v_splat_x(xyzw), abcd), v_rot_2(xyzw), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xycw(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(xyzw), v_merge_lw(abcd, v_splat_w(xyzw)), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xyzd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_3(xyzw), v_splat_w(abcd), 1); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xbcd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_splat_x(xyzw), v_rot_1(abcd), 3); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_aycd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_merge_hw(v_splat_x(abcd), xyzw), v_rot_2(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_abzd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(abcd), v_merge_lw(xyzw, v_splat_w(abcd)), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_abcw(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_3(abcd), v_splat_w(xyzw), 1); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xycd(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(xyzw), v_rot_2(abcd), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_abzw(vec4f xyzw, vec4f abcd) { return V_SHIFT(v_rot_2(abcd), v_rot_2(xyzw), 2); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xbcw(vec4f xyzw, vec4f abcd)
 {
   return V_SHIFT(v_merge_hw(v_splat_x(xyzw), abcd), v_merge_lw(abcd, v_splat_w(xyzw)), 2);
@@ -217,36 +222,36 @@ VECMATH_FINLINE vec4f VECTORCALL
 
 
 #if !_TARGET_SIMD_NEON
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq(vec4f a) { return v_dot4(a,a); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq(vec3f a) { return v_dot3(a,a); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq(vec4f a) { return v_dot2(a,a); }
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq_x(vec4f a) { return v_dot4_x(a,a); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq_x(vec3f a) { return v_dot3_x(a,a); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq_x(vec4f a) { return v_dot2_x(a,a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a) { return v_dot4(a,a); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a) { return v_dot3(a,a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a) { return v_dot2(a,a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_dot4_x(a,a); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a) { return v_dot3_x(a,a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a) { return v_dot2_x(a,a); }
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_length4(vec4f a) { return v_sqrt4(v_length4_sq(a)); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3(vec3f a) { return v_sqrt4(v_length3_sq(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2(vec4f a) { return v_sqrt4(v_length2_sq(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length4_est(vec4f a) { return v_sqrt4_fast(v_length4_sq(a)); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_est(vec3f a) { return v_sqrt4_fast(v_length3_sq(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_est(vec4f a) { return v_sqrt4_fast(v_length2_sq(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length4_x(vec4f a) { return v_sqrt_x(v_length4_sq_x(a)); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_x(vec3f a) { return v_sqrt_x(v_length3_sq_x(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_x(vec4f a) { return v_sqrt_x(v_length2_sq_x(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length4_est_x(vec4f a) { return v_sqrt_fast_x(v_length4_sq_x(a)); }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_est_x(vec3f a) { return v_sqrt_fast_x(v_length3_sq_x(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_est_x(vec4f a) { return v_sqrt_fast_x(v_length2_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4(vec4f a) { return v_sqrt4(v_length4_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3(vec3f a) { return v_sqrt4(v_length3_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2(vec4f a) { return v_sqrt4(v_length2_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est(vec4f a) { return v_sqrt4_fast(v_length4_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est(vec3f a) { return v_sqrt4_fast(v_length3_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est(vec4f a) { return v_sqrt4_fast(v_length2_sq(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_x(vec4f a) { return v_sqrt_x(v_length4_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_x(vec3f a) { return v_sqrt_x(v_length3_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_x(vec4f a) { return v_sqrt_x(v_length2_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_est_x(vec4f a) { return v_sqrt_fast_x(v_length4_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec3f v_length3_est_x(vec3f a) { return v_sqrt_fast_x(v_length3_sq_x(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_length2_est_x(vec4f a) { return v_sqrt_fast_x(v_length2_sq_x(a)); }
 
-VECMATH_FINLINE vec3f VECTORCALL v_striple3(vec3f a, vec3f b, vec3f c) { return v_dot3(v_cross3(a, b), c); }
-VECMATH_FINLINE vec3f VECTORCALL v_vtriple3(vec3f a, vec3f b, vec3f c)
+VECTORCALL VECMATH_FINLINE vec3f v_striple3(vec3f a, vec3f b, vec3f c) { return v_dot3(v_cross3(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec3f v_vtriple3(vec3f a, vec3f b, vec3f c)
 {
   vec3f ac = v_dot3(a, c);
   vec3f ab = v_dot3(a, b);
   return v_nmsub(c, ab, v_mul(b, ac));
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_cross3(vec3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec3f v_cross3(vec3f a, vec3f b)
 {
   // a.y * b.z - a.z * b.y
   // a.z * b.x - a.x * b.z
@@ -259,7 +264,7 @@ VECMATH_FINLINE vec3f VECTORCALL v_cross3(vec3f a, vec3f b)
   return v_sub(tmp3, tmp4);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_forward(mat44f &dest, float wk, float hk, float zn, float zf)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp_forward(mat44f &dest, float wk, float hk, float zn, float zf)
 {
   float q = zf/(zf-zn);
   dest.col0 = v_make_vec4f(wk, 0, 0, 0);
@@ -268,7 +273,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_forward(mat44f &dest, float w
   dest.col3 = v_make_vec4f(0, 0, -q*zn, 0);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_reverse(mat44f &dest, float wk, float hk, float zn, float zf)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp_reverse(mat44f &dest, float wk, float hk, float zn, float zf)
 {
   dest.col0 = v_make_vec4f(wk, 0, 0, 0);
   dest.col1 = v_make_vec4f(0, hk, 0, 0);
@@ -276,14 +281,14 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_persp_reverse(mat44f &dest, float w
   dest.col3 = v_make_vec4f(0, 0, (zn*zf)/(zf-zn), 0);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_persp(mat44f &dest, float wk, float hk, float zn, float zf)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_persp(mat44f &dest, float wk, float hk, float zn, float zf)
 {
   return v_mat44_make_persp_reverse(dest, wk, hk, zn, zf);
 }
 
 
 #if !_TARGET_SIMD_SSE
-VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, vec3f col0, vec3f col1, vec3f col2)
+VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, vec3f col0, vec3f col1, vec3f col2)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(col0, col2);
@@ -295,7 +300,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, vec3f col0, vec3
   dest.col2 = v_merge_hw(tmp2, tmp3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec3f col3)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, vec3f col3)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(col0, col2);
@@ -308,7 +313,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f c
 }
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_remove_not_finite(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_remove_not_finite(vec4f a)
 {
   static vec4i_const infMask = { 0x7F800000, 0x7F800000, 0x7F800000, 0x7F800000 };
   vec4i ai = v_cast_vec4i(a);
@@ -316,25 +321,25 @@ VECMATH_FINLINE vec4f VECTORCALL v_remove_not_finite(vec4f a)
 }
 
 #if defined(__FINITE_MATH_ONLY__) && __FINITE_MATH_ONLY__ > 0 // Clang/GCC
-VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_remove_nan(vec4f a)
 {
   static vec4i_const minNan = { 0x7F800001, 0x7F800001, 0x7F800001, 0x7F800001 };
   vec4i am = v_andi(v_cast_vec4i(a), V_CI_INV_SIGN_MASK);
   return v_cast_vec4f(v_andi(v_cast_vec4i(a), v_cmp_lti(am, minNan)));
 }
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_remove_nan(vec4f a) {return v_and(a, v_cmp_eq(a,a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_remove_nan(vec4f a) {return v_and(a, v_cmp_eq(a,a)); }
 #endif
-VECMATH_FINLINE vec4f VECTORCALL v_norm4_safe(vec4f a) {return v_remove_not_finite(v_norm4(a));}
-VECMATH_FINLINE vec4f VECTORCALL v_norm3_safe(vec4f a) {return v_remove_not_finite(v_norm3(a));}
-VECMATH_FINLINE vec4f VECTORCALL v_norm2_safe(vec4f a) {return v_remove_not_finite(v_norm2(a));}
+VECTORCALL VECMATH_FINLINE vec4f v_norm4_safe(vec4f a) {return v_remove_not_finite(v_norm4(a));}
+VECTORCALL VECMATH_FINLINE vec4f v_norm3_safe(vec4f a) {return v_remove_not_finite(v_norm3(a));}
+VECTORCALL VECMATH_FINLINE vec4f v_norm2_safe(vec4f a) {return v_remove_not_finite(v_norm2(a));}
 
-VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, mat33f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, mat33f_cref src)
 {
   v_mat33_transpose(dest, src.col0, src.col1, src.col2);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat33_make_from_look(mat33f &dest, vec4f look_dir)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_from_look(mat33f &dest, vec4f look_dir)
 {
   vec4f vx = v_cross3(V_C_UNIT_0100, look_dir);
   vec4f vxlsq = v_length3_sq(vx);
@@ -355,7 +360,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_from_look(mat33f &dest, vec4f look_
   dest.col2 = look_dir;
 }
 
-VECMATH_INLINE void VECTORCALL v_view_matrix_from_tangentZ( vec3f &left, vec3f &up, vec4f vdir )
+VECTORCALL VECMATH_INLINE  void v_view_matrix_from_tangentZ( vec3f &left, vec3f &up, vec4f vdir )
 {
   up = v_sel(V_C_UNIT_0010, V_C_UNIT_1000, v_cmp_gt(v_abs(v_splat_z(vdir)), v_splats(0.999f)));
   left = v_norm3(v_cross3(up, vdir));
@@ -363,13 +368,13 @@ VECMATH_INLINE void VECTORCALL v_view_matrix_from_tangentZ( vec3f &left, vec3f &
 }
 
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make33_from_look(mat44f &dest, vec4f look_dir)
+VECTORCALL VECMATH_FINLINE void v_mat44_make33_from_look(mat44f &dest, vec4f look_dir)
 {
   mat33f m;
   v_mat33_make_from_look(m, look_dir);
   dest.set33(m);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_make_look_at(mat44f &dest, vec4f eye, vec4f at, vec4f up)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_look_at(mat44f &dest, vec4f eye, vec4f at, vec4f up)
 {
   dest.col2 = v_norm3(v_sub(at, eye));
   dest.col0 = v_norm3(v_cross3(up, dest.col2));
@@ -378,7 +383,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_look_at(mat44f &dest, vec4f eye, ve
   v_mat44_orthonormal_inverse43_to44(dest, dest);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_ortho(mat44f &dest, float _w, float _h, float _zn, float _zf)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_ortho(mat44f &dest, float _w, float _h, float _zn, float _zf)
 {
   v_mat44_ident(dest);
   vec4f zn = v_splat4(&_zn);
@@ -392,89 +397,89 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_ortho(mat44f &dest, float _w, float
   dest.col3 = v_madd(zn, dest.col2, dest.col3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_add(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_add(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   dest.col0 = v_add(m1.col0, m2.col0);
   dest.col1 = v_add(m1.col1, m2.col1);
   dest.col2 = v_add(m1.col2, m2.col2);
   dest.col3 = v_add(m1.col3, m2.col3);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_add(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_add(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
 {
   dest.col0 = v_add(m1.col0, m2.col0);
   dest.col1 = v_add(m1.col1, m2.col1);
   dest.col2 = v_add(m1.col2, m2.col2);
 }
-VECMATH_FINLINE void VECTORCALL v_mat43_sub(mat43f &dest, mat43f_cref m1, mat43f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat43_sub(mat43f &dest, mat43f_cref m1, mat43f_cref m2)
 {
   dest.row0 = v_sub(m1.row0, m2.row0);
   dest.row1 = v_sub(m1.row1, m2.row1);
   dest.row2 = v_sub(m1.row2, m2.row2);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_sub(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_sub(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   dest.col0 = v_sub(m1.col0, m2.col0);
   dest.col1 = v_sub(m1.col1, m2.col1);
   dest.col2 = v_sub(m1.col2, m2.col2);
   dest.col3 = v_sub(m1.col3, m2.col3);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_sub(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_sub(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
 {
   dest.col0 = v_sub(m1.col0, m2.col0);
   dest.col1 = v_sub(m1.col1, m2.col1);
   dest.col2 = v_sub(m1.col2, m2.col2);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat33_from_mat44(mat33f &dest, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_from_mat44(mat33f &dest, mat44f_cref m2)
 {
   dest.col0 = m2.col0;
   dest.col1 = m2.col1;
   dest.col2 = m2.col2;
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat33_neg(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_neg(mat44f &dest, mat44f_cref m)
 {
   vec4f zero = v_zero();
   dest.col0 = v_sub(zero, m.col0);
   dest.col1 = v_sub(zero, m.col1);
   dest.col2 = v_sub(zero, m.col2);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_neg(mat33f &dest, mat33f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_neg(mat33f &dest, mat33f_cref m)
 {
   vec4f zero = v_zero();
   dest.col0 = v_sub(zero, m.col0);
   dest.col1 = v_sub(zero, m.col1);
   dest.col2 = v_sub(zero, m.col2);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_mul_elem(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul_elem(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   dest.col0 = v_mul(m1.col0, m2.col0);
   dest.col1 = v_mul(m1.col1, m2.col1);
   dest.col2 = v_mul(m1.col2, m2.col2);
   dest.col3 = v_mul(m1.col3, m2.col3);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_mul_elem(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_mul_elem(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
 {
   dest.col0 = v_mul(m1.col0, m2.col0);
   dest.col1 = v_mul(m1.col1, m2.col1);
   dest.col2 = v_mul(m1.col2, m2.col2);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_mat43_mul_vec3v(mat43f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3v(mat43f_cref m, vec3f v)
 {
   mat44f m44;
   v_mat43_transpose_to_mat44(m44, m);
   return v_mat44_mul_vec3v(m44, v);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_mat43_mul_vec3p(mat43f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec3f v_mat43_mul_vec3p(mat43f_cref m, vec3f v)
 {
   mat44f m44;
   v_mat43_transpose_to_mat44(m44, m);
   return v_mat44_mul_vec3p(m44, v);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   vec4f col0 = v_mat44_mul_vec4(m1, m2.col0);
   vec4f col1 = v_mat44_mul_vec4(m1, m2.col1);
@@ -485,7 +490,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_mul(mat44f &dest, mat44f_cref m1, mat44f
   dest.col2 = col2;
   dest.col3 = col3;
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   vec4f col0 = v_mat44_mul_vec3v(m1, m2.col0);
   vec4f col1 = v_mat44_mul_vec3v(m1, m2.col1);
@@ -497,7 +502,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat4
   dest.col3 = col3;
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat43f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat43f_cref m2)
 {
   vec4f xxxx, yyyy, zzzz;
   #define SPLAT_MAT_N_COL0(N, COL) \
@@ -520,7 +525,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_mul43(mat44f &dest, mat44f_cref m1, mat4
   #undef SPLAT_MAT_N_COL1
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_mul33r(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul33r(mat44f &dest, mat44f_cref m1, mat44f_cref m2)
 {
   vec4f col0 = v_mat44_mul_vec3v(m1, m2.col0);
   vec4f col1 = v_mat44_mul_vec3v(m1, m2.col1);
@@ -530,7 +535,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_mul33r(mat44f &dest, mat44f_cref m1, mat
   dest.col2 = col2;
   dest.col3 = m1.col3;
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_mul33(mat44f &dest, mat44f_cref m1, mat33f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul33(mat44f &dest, mat44f_cref m1, mat33f_cref m2)
 {
   vec4f col0 = v_mat44_mul_vec3v(m1, m2.col0);
   vec4f col1 = v_mat44_mul_vec3v(m1, m2.col1);
@@ -540,7 +545,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_mul33(mat44f &dest, mat44f_cref m1, mat3
   dest.col2 = col2;
   dest.col3 = m1.col3;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_mul(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_mul(mat33f &dest, mat33f_cref m1, mat33f_cref m2)
 {
   vec4f col0 = v_mat33_mul_vec3(m1, m2.col0);
   vec4f col1 = v_mat33_mul_vec3(m1, m2.col1);
@@ -549,7 +554,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_mul(mat33f &dest, mat33f_cref m1, mat33f
   dest.col1 = col1;
   dest.col2 = col2;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat44f_cref m2)
+VECTORCALL VECMATH_FINLINE void v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat44f_cref m2)
 {
   vec4f col0 = v_mat33_mul_vec3(m1, m2.col0);
   vec4f col1 = v_mat33_mul_vec3(m1, m2.col1);
@@ -558,7 +563,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_mul33r(mat33f &dest, mat33f_cref m1, mat
   dest.col1 = col1;
   dest.col2 = col2;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_orthonormalize(mat33f &dest, mat33f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_orthonormalize(mat33f &dest, mat33f_cref m)
 {
   vec4f c2 = v_norm3(v_cross3(m.col0, m.col1));
   vec4f c1 = v_norm3(v_cross3(c2, m.col0));
@@ -567,7 +572,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_orthonormalize(mat33f &dest, mat33f_cref
   dest.col1 = c1;
   dest.col0 = c0;
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormalize33(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormalize33(mat44f &dest, mat44f_cref m)
 {
   vec4f c2 = v_norm3(v_cross3(m.col0, m.col1));
   vec4f c1 = v_norm3(v_cross3(c2, m.col0));
@@ -576,12 +581,12 @@ VECMATH_FINLINE void VECTORCALL v_mat44_orthonormalize33(mat44f &dest, mat44f_cr
   dest.col1 = c1;
   dest.col0 = c0;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_orthonormal_inverse(mat33f &dest, mat33f_cref m)
 {
   v_mat33_transpose(dest, m);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
   v_mat44_transpose_to_mat33(m3, m.col0, m.col1, m.col2, v_zero());
@@ -589,7 +594,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43(mat44f &dest, mat4
   dest.col3 = v_neg(v_mat44_mul_vec3v(dest, m.col3));
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_orthonormal_inverse43_to44(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
   v_mat44_transpose_to_mat33(m3, m.col0, m.col1, m.col2, v_zero());
@@ -597,11 +602,11 @@ VECMATH_FINLINE void VECTORCALL v_mat44_orthonormal_inverse43_to44(mat44f &dest,
   dest.col3 = v_perm_xyzd(v_neg(v_mat44_mul_vec3v(dest, m.col3)), V_C_UNIT_0001);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat33_det(mat33f_cref m)
+VECTORCALL VECMATH_FINLINE vec4f v_mat33_det(mat33f_cref m)
 {
   return v_dot3(m.col2, v_cross3(m.col0, m.col1));
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse43(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse43(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
   m3.col0 = m.col0;
@@ -612,7 +617,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse43(mat44f &dest, mat44f_cref m)
   dest.col3 = v_neg(v_mat44_mul_vec3v(dest, m.col3));
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse43_to44(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse43_to44(mat44f &dest, mat44f_cref m)
 {
   mat33f m3;
   m3.col0 = m.col0;
@@ -627,29 +632,29 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse43_to44(mat44f &dest, mat44f_cref
   dest.col3 = v_perm_xyzd(v_neg(v_mat44_mul_vec3v(dest, m.col3)), V_C_UNIT_0001);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_det43(mat44f_cref m)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det43(mat44f_cref m)
 {
   return v_dot3(m.col2, v_cross3(m.col0, m.col1));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43_sq(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_sq(mat44f_cref tm)
 {
   vec4f xScaleSq = v_length3_sq(tm.col0);
   vec4f yScaleSq = v_length3_sq(tm.col1);
   vec4f zScaleSq = v_length3_sq(tm.col2);
   return v_max(xScaleSq, v_max(yScaleSq, zScaleSq));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43(mat44f_cref tm)
 {
   return v_sqrt4(v_mat44_max_scale43_sq(tm));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_max_scale43_x(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_max_scale43_x(mat44f_cref tm)
 {
   vec4f xScaleSq = v_length3_sq_x(tm.col0);
   vec4f yScaleSq = v_length3_sq_x(tm.col1);
   vec4f zScaleSq = v_length3_sq_x(tm.col2);
   return v_sqrt_x(v_max(xScaleSq, v_max(yScaleSq, zScaleSq)));
 }
-VECMATH_FINLINE vec3f VECTORCALL v_mat44_scale43_sq(mat44f_cref tm)
+VECTORCALL VECMATH_FINLINE vec3f v_mat44_scale43_sq(mat44f_cref tm)
 {
   vec4f xScaleSq = v_length3_sq(tm.col0);
   vec4f yScaleSq = v_length3_sq(tm.col1);
@@ -657,29 +662,29 @@ VECMATH_FINLINE vec3f VECTORCALL v_mat44_scale43_sq(mat44f_cref tm)
   return v_perm_xzac(v_perm_xycd(xScaleSq, yScaleSq), zScaleSq);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_bsph(mat44f_cref m, vec4f bsph)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_bsph(mat44f_cref m, vec4f bsph)
 {
   return v_perm_xyzd(v_mat44_mul_vec3p(m, bsph), v_mul(bsph, v_mat44_max_scale43(m)));
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_mul_bsph(mat44f_cref m, vec4f &bsph_pos, vec4f &bsph_rad_x)
+VECTORCALL VECMATH_FINLINE void v_mat44_mul_bsph(mat44f_cref m, vec4f &bsph_pos, vec4f &bsph_rad_x)
 {
   bsph_pos = v_mat44_mul_vec3p(m, bsph_pos);
   bsph_rad_x = v_mul_x(bsph_rad_x, v_mat44_max_scale43_x(m));
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_empty(bbox3f &b)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_empty(bbox3f &b)
 {
   b.bmin = V_C_MAX_VAL;
   b.bmax = v_sub(v_zero(), b.bmin);
 }
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_ident(bbox3f &b)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_ident(bbox3f &b)
 {
   b.bmin = v_neg(V_C_HALF);
   b.bmax = V_C_HALF;
 }
-VECMATH_FINLINE void VECTORCALL v_bbox3_init(bbox3f &b, vec3f p) { b.bmin = b.bmax = p; }
-VECMATH_FINLINE void VECTORCALL v_bbox3_init(bbox3f &b, mat44f_cref m, bbox3f b2)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, vec3f p) { b.bmin = b.bmax = p; }
+VECTORCALL VECMATH_FINLINE void v_bbox3_init(bbox3f &b, mat44f_cref m, bbox3f b2)
 {
   // What we're doing here is this:
   // xxxx*m0 + yyyy*m1 + zzzz*m2 + m3
@@ -717,74 +722,74 @@ VECMATH_FINLINE void VECTORCALL v_bbox3_init(bbox3f &b, mat44f_cref m, bbox3f b2
   b.bmax = v_add(b.bmax, m.col3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_bsph(bbox3f &b, vec3f bsph_center, vec3f bsph_radius)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_bsph(bbox3f &b, vec3f bsph_center, vec3f bsph_radius)
 {
   b.bmin = v_sub(bsph_center, bsph_radius);
   b.bmax = v_add(bsph_center, bsph_radius);
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len)
 {
   v_bbox3_init_by_segment(b, from, v_madd(dir, len, from));
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_init_by_segment(bbox3f &b, vec4f from, vec4f to)
+VECTORCALL VECMATH_FINLINE void v_bbox3_init_by_segment(bbox3f &b, vec4f from, vec4f to)
 {
   b.bmin = v_min(from, to);
   b.bmax = v_max(from, to);
 }
 
 //return all mask if empty
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_center(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_center(bbox3f b)
 {
   return v_mul(v_add(b.bmin, b.bmax), V_C_HALF);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_outer_rad(bbox3f b)
 {
   return v_mul_x(V_C_HALF, v_length3_x(v_bbox3_size(b)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_diameter(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_inner_diameter(bbox3f b)
 {
   return v_hmin3(v_bbox3_size(b));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_inner_rad(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_inner_rad(bbox3f b)
 {
   return v_mul_x(V_C_HALF, v_bbox3_inner_diameter(b));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_bbox3_outer_rad_from_zero(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_bbox3_outer_rad_from_zero(bbox3f b)
 {
   return v_length3_x(v_max(v_neg(b.bmin), b.bmax));
 }
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_point(bbox3f b, int idx)
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_point(bbox3f b, int idx)
 {
   return v_sel(b.bmin, b.bmax, v_make_vec4f_mask(uint8_t(idx)));
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_pt(bbox3f &b, vec3f p)
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_pt(bbox3f &b, vec3f p)
 {
   b.bmin = v_min(b.bmin, p);
   b.bmax = v_max(b.bmax, p);
 }
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_box(bbox3f &b, bbox3f b2)
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_box(bbox3f &b, bbox3f b2)
 {
   b.bmin = v_min(b.bmin, b2.bmin);
   b.bmax = v_max(b.bmax, b2.bmax);
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_transformed_box(bbox3f &b, mat44f_cref m, bbox3f b2)
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_transformed_box(bbox3f &b, mat44f_cref m, bbox3f b2)
 {
   bbox3f temp;
   v_bbox3_init(temp, m, b2);
   v_bbox3_add_box(b, temp);
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_add_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len)
+VECTORCALL VECMATH_FINLINE void v_bbox3_add_ray(bbox3f &b, vec3f from, vec3f dir, vec4f len)
 {
   v_bbox3_add_pt(b, from);
   v_bbox3_add_pt(b, v_madd(dir, len, from));
 }
 
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sum(bbox3f b1, bbox3f b2)
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_sum(bbox3f b1, bbox3f b2)
 {
   bbox3f b;
   b.bmin = v_min(b1.bmin, b2.bmin);
@@ -792,7 +797,7 @@ VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sum(bbox3f b1, bbox3f b2)
   return b;
 }
 
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sel(bbox3f b1, bbox3f b2, vec4f c)
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_sel(bbox3f b1, bbox3f b2, vec4f c)
 {
   bbox3f b;
   b.bmin = v_sel(b1.bmin, b2.bmin, c);
@@ -800,13 +805,13 @@ VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_sel(bbox3f b1, bbox3f b2, vec4f c)
   return b;
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_size(bbox3f b) { return v_sub(b.bmax, b.bmin); }
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_size(bbox3f b) { return v_sub(b.bmax, b.bmin); }
 
-VECMATH_FINLINE vec3f VECTORCALL v_bbox3_max_size(bbox3f b)
+VECTORCALL VECMATH_FINLINE vec3f v_bbox3_max_size(bbox3f b)
 {
   return v_hmax3(v_bbox3_size(b));
 }
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_scale(bbox3f b, vec4f size_factor)
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_scale(bbox3f b, vec4f size_factor)
 {
   vec3f center = v_bbox3_center(b);
   return bbox3f
@@ -815,42 +820,42 @@ VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_scale(bbox3f b, vec4f size_factor)
     v_lerp_vec4f(size_factor, center, b.bmax)
   };
 }
-VECMATH_FINLINE bool VECTORCALL v_bbox3_is_empty(bbox3f bbox)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_is_empty(bbox3f bbox)
 {
   vec4f invalid = v_cmp_gt(bbox.bmin, bbox.bmax);
   return v_check_xyz_any_not_zeroi(invalid);
 }
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_pt_inside(bbox3f b, vec3f p)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_pt_inside(bbox3f b, vec3f p)
 {
   vec3f inside = v_and(v_cmp_ge(p, b.bmin), v_cmp_ge(b.bmax, p));
   return v_check_xyz_all_not_zeroi(inside);
 }
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_inside(bbox3f b1, bbox3f b2)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_inside(bbox3f b1, bbox3f b2)
 {
   vec3f insideMin = v_and(v_cmp_ge(b2.bmin, b1.bmin), v_cmp_ge(b1.bmax, b2.bmin));
   vec3f insideMax = v_and(v_cmp_ge(b2.bmax, b1.bmin), v_cmp_ge(b1.bmax, b2.bmax));
   return v_check_xyz_all_not_zeroi(v_and(insideMin, insideMax));
 }
 
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_intersect(bbox3f b1, bbox3f b2)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect(bbox3f b1, bbox3f b2)
 {
   vec3f m = v_and(v_cmp_ge(b2.bmax, b1.bmin), v_cmp_ge(b1.bmax, b2.bmin));
   return v_check_xyz_all_not_zeroi(m);
 }
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_box_intersect_safe(bbox3f b1, bbox3f b2)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_box_intersect_safe(bbox3f b1, bbox3f b2)
 {
   vec3f m = v_and(v_and(v_cmp_ge(b1.bmax, b1.bmin), v_cmp_ge(b2.bmax, b2.bmin)),
     v_and(v_cmp_ge(b2.bmax, b1.bmin), v_cmp_ge(b1.bmax, b2.bmin)));
   return v_check_xyz_all_not_zeroi(m);
 }
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_pt_inside_xz(bbox3f b, vec3f p)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_pt_inside_xz(bbox3f b, vec3f p)
 {
   vec3f m = v_and(v_cmp_ge(p, b.bmin), v_cmp_ge(b.bmax, p));
   return !v_test_vec_x_eqi_0(v_and(m, v_splat_z(m)));
 }
 
 // Checking only planes intersection! You need to test AvsB + BvsA and check inside case for each.
-inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect_no_check(bbox3f box0, bbox3f box1, const mat44f& tm1)
+VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect_no_check(bbox3f box0, bbox3f box1, const mat44f& tm1)
 {
   vec3f msbit = v_msbit();
   vec3f elemMask0 = v_cast_vec4f(v_seti_x(-1));
@@ -927,7 +932,7 @@ inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect_no_check(bbox3f box
   return false;
 }
 
-inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1)
+VECTORCALL inline bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f box1, const mat44f& tm1)
 {
   // fast check for box1 completely inside box0, or not even roughly intersects
   bbox3f box1AABB;
@@ -939,7 +944,7 @@ inline bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, bbox3f
   return v_bbox3_test_trasformed_box_intersect_no_check(box0, box1, tm1);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1,
                                                                       vec4f size_factor)
 {
   // validate
@@ -973,12 +978,12 @@ VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box
   return false;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect(bbox3f box0, const mat44f& tm0, bbox3f box1, const mat44f& tm1)
 {
   return v_bbox3_test_trasformed_box_intersect(box0, tm0, box1, tm1, V_C_ONE);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_trasformed_box_intersect_rel_tm(bbox3f box0, const mat44f& b0_to_b1,
                                                                              bbox3f box1, const mat44f& b1_to_b0)
 {
   bbox3f box1inb0;
@@ -1003,25 +1008,25 @@ VECMATH_FINLINE bool VECTORCALL v_bbox3_test_trasformed_box_intersect_rel_tm(bbo
   return false;
 }
 
-VECMATH_FINLINE bbox3f VECTORCALL v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1)
+VECTORCALL VECMATH_FINLINE bbox3f v_bbox3_get_box_intersection(bbox3f box0, bbox3f box1)
 {
   return bbox3f { v_max(box0.bmin, box1.bmin), v_min(box0.bmax, box1.bmax) };
 }
 
-VECMATH_FINLINE bool VECTORCALL v_bbox3_test_sph_intersect(bbox3f box, vec4f bsph_center, vec4f bsph_r2_x)
+VECTORCALL VECMATH_FINLINE bool v_bbox3_test_sph_intersect(bbox3f box, vec4f bsph_center, vec4f bsph_r2_x)
 {
   vec4f distSq = v_length3_sq_x(v_add(v_max(v_sub(box.bmin, bsph_center), v_zero()),
                                       v_max(v_sub(bsph_center, box.bmax), v_zero()))); // Dist from sph center to bounding box squared
   return v_test_vec_x_le_0(v_sub_x(distSq, bsph_r2_x));
 }
 
-VECMATH_FINLINE void VECTORCALL v_bbox3_extend(bbox3f &b, vec3f ext)
+VECTORCALL VECMATH_FINLINE void v_bbox3_extend(bbox3f &b, vec3f ext)
 {
   b.bmin = v_sub(b.bmin, ext);
   b.bmax = v_add(b.bmax, ext);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_bbox2_extend(vec4f box2d, vec4f ext)
+VECTORCALL VECMATH_FINLINE vec4f v_bbox2_extend(vec4f box2d, vec4f ext)
 {
   return v_perm_xycd(v_sub(box2d, ext), v_add(box2d, ext));
 }
@@ -1196,87 +1201,65 @@ VECMATH_FINLINE void v_bsph_add_bbox_unsafe(vec4f& sph, bbox3f b)
   sph = v_perm_xyzd(sph, v_max(sph, r));
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_quat_lerp(vec4f tttt, quat4f a, quat4f b)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_lerp(vec4f tttt, quat4f a, quat4f b)
 {
   return v_lerp_vec4f(tttt, a, b);
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_quat_conjugate(quat4f q) { return v_perm_xyzd(v_neg(q), q); }
+VECTORCALL VECMATH_FINLINE quat4f v_quat_conjugate(quat4f q) { return v_perm_xyzd(v_neg(q), q); }
 
-VECMATH_FINLINE vec3f VECTORCALL v_quat_mul_vec3(quat4f q, vec3f v)
+VECTORCALL VECMATH_FINLINE vec3f v_quat_mul_vec3(quat4f q, vec3f v)
 {
   vec3f t = v_cross3(q, v);
   t = v_add(t,t);//*2
   return v_add(v, v_madd(v_splat_w(q), t, v_cross3(q, t)));//v + q.w * t + v_cross3(q.xyz, t);
 }
 
-#if _TARGET_SIMD_VMX|_TARGET_SIMD_SPU|_TARGET_SIMD_SSE
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat(vec3f col0, vec3f col1, vec3f col2)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat(vec3f col0, vec3f col1, vec3f col2)
 {
-  vec4f xx_yy, xx_yy_zz_xx, yy_zz_xx_yy, zz_xx_yy_zz, diagSum, diagDiff;
-  vec4f zy_xz_yx, yz_zx_xy, sum, diff;
-  vec4f radicand, invSqrt, scale;
-  vec4f res0, res1, res2, res3;
-  vec4f xx, yy, zz;
-  quat4f res;
+  /* compute quaternion for each case */
+  vec4f _yz_ = v_perm_xycd(col1, col2);
+  vec4f xyz = v_perm_ayzw(_yz_, col0);
+  vec4f yzx = v_perm_xyab(v_perm_yzwx(_yz_), col0);
+  vec4f zxy = v_perm_zxyw(xyz);
 
-  xx_yy = v_perm_xbzw(col0, col1);
-#if _TARGET_SIMD_VMX|_TARGET_SIMD_SPU
-  xx_yy_zz_xx = v_perm_xycx(xx_yy, col2);
-  yy_zz_xx_yy = v_perm_ycxy(xx_yy, col2);
-  zz_xx_yy_zz = v_perm_cxyc(xx_yy, col2);
-#elif _TARGET_SIMD_SSE
-  xx_yy_zz_xx = v_perm_xycw(_mm_shuffle_ps(xx_yy, xx_yy, _MM_SHUFFLE(0,0,1,0)), col2);
-  yy_zz_xx_yy = _mm_shuffle_ps(xx_yy_zz_xx, xx_yy_zz_xx, _MM_SHUFFLE(1,0,2,1));
-  zz_xx_yy_zz = _mm_shuffle_ps(xx_yy_zz_xx, xx_yy_zz_xx, _MM_SHUFFLE(2,1,0,2));
-#endif
+  vec4f diagSum = v_add(v_add(xyz, yzx), zxy);
+  vec4f diagDiff = v_sub(v_sub(xyz, yzx), zxy);
+  vec4f radicand = v_add(v_perm_xyzd(diagDiff, v_splat_x(diagSum)), V_C_ONE);
+  vec4f invSqrt = v_rsqrt4(v_sel(radicand, V_C_ONE, v_cmp_ge(v_zero(), radicand)));
 
-  diagSum = v_add(v_add(xx_yy_zz_xx, yy_zz_xx_yy), zz_xx_yy_zz );
-  diagDiff = v_sub(v_sub(xx_yy_zz_xx, yy_zz_xx_yy), zz_xx_yy_zz );
-  radicand = v_add(v_perm_xyzd(diagDiff, diagSum), V_C_ONE);
-  invSqrt = v_rsqrt4(v_sel(radicand, V_C_ONE, v_cmp_ge(v_zero(), radicand)));
+  vec4f zy_xz_yx = v_perm_zayx(v_perm_xycw(col0, col1), col2);
+  vec4f yz_zx_xy = v_perm_bzxx(v_perm_ayzw(col0, col1), col2);
+  vec4f sum = v_add(zy_xz_yx, yz_zx_xy);
+  vec4f diff = v_sub(zy_xz_yx, yz_zx_xy);
 
-  zy_xz_yx = v_perm_xycw(col0, col1);
-  zy_xz_yx = v_perm_zayx(zy_xz_yx, col2);
-  yz_zx_xy = v_perm_ayzw(col0, col1);
-  yz_zx_xy = v_perm_bzxx(yz_zx_xy, col2);
+  vec4f scale = v_mul(invSqrt, V_C_HALF);
+  vec4f res0 = v_mul(v_perm_ayzw(v_perm_xzya(sum, diff), radicand), v_splat_x(scale));
+  vec4f res1 = v_mul(v_perm_xbzw(v_perm_zxxb(sum, diff), radicand), v_splat_y(scale));
+  vec4f res2 = v_mul(v_perm_xycw(v_perm_yxxc(sum, diff), radicand), v_splat_z(scale));
+  vec4f res3 = v_mul(v_perm_xyzd(diff, radicand), v_splat_w(scale));
 
-  sum = v_add(zy_xz_yx, yz_zx_xy);
-  diff = v_sub(zy_xz_yx, yz_zx_xy);
+  /* determine case and select answer */
+  vec4f xx = v_splat_x(col0);
+  vec4f yy = v_splat_y(col1);
+  vec4f zz = v_splat_z(col2);
 
-  scale = v_mul(invSqrt, V_C_HALF);
-  res0 = v_perm_xzya(sum, diff);
-  res1 = v_perm_zxxb(sum, diff);
-  res2 = v_perm_yxxc(sum, diff);
-  res3 = diff;
-  res0 = v_perm_ayzw(res0, radicand);
-  res1 = v_perm_xbzw(res1, radicand);
-  res2 = v_perm_xycw(res2, radicand);
-  res3 = v_perm_xyzd(res3, radicand);
-  res0 = v_mul( res0, v_splat_x(scale));
-  res1 = v_mul( res1, v_splat_y(scale));
-  res2 = v_mul( res2, v_splat_z(scale));
-  res3 = v_mul( res3, v_splat_w(scale));
-
-  xx = v_splat_x(col0);
-  yy = v_splat_y(col1);
-  zz = v_splat_z(col2);
-  res = v_sel(res0, res1, v_cmp_gt(yy, xx));
-  res = v_sel(res, res2, v_and(v_cmp_gt(zz, xx), v_cmp_gt(zz, yy)));
-  return v_sel(res, res3, v_cmp_gt(v_splat_x(diagSum), v_zero()));
+  vec4f q = v_sel(res0, res1, v_cmp_gt(yy, xx));
+  q = v_sel(q, res2, v_and(v_cmp_gt(zz, xx), v_cmp_gt(zz, yy)));
+  return v_norm4(v_sel(q, res3, v_cmp_ge(v_splat_x(diagSum), v_zero())));
 }
-#endif
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat3(mat33f_cref m)
+
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat33(mat33f_cref m)
 {
-  return v_un_quat_from_mat(m.col0, m.col1, m.col2);
+  return v_quat_from_mat(m.col0, m.col1, m.col2);
 }
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat4(mat44f_cref m)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_mat43(mat44f_cref m)
 {
-  return v_un_quat_from_mat(m.col0, m.col1, m.col2);
+  return v_quat_from_mat(m.col0, m.col1, m.col2);
 }
 
 //! make quaternion to rotate 'v0' to 'v1'; v0 and v1 must be normalized
-VECMATH_FINLINE quat4f VECTORCALL v_quat_from_unit_arc(vec3f v0, vec3f v1)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_unit_arc(vec3f v0, vec3f v1)
 {
   vec4f cosAngle = v_dot3(v0, v1);
   vec4f cosAngleX2Plus2 = v_madd_x(cosAngle, V_C_TWO, V_C_TWO);
@@ -1296,7 +1279,7 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_from_unit_arc(vec3f v0, vec3f v1)
 }
 
 //! make quaternion to rotate 'v0' to 'v1'
-VECMATH_FINLINE quat4f VECTORCALL v_quat_from_arc(vec3f v0, vec3f v1)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_from_arc(vec3f v0, vec3f v1)
 {
   vec4f inv_len_product = v_rsqrt_x(v_mul_x(v_length3_sq_x(v0), v_length3_sq_x(v1)));
   vec4f cosAngle = v_mul_x(v_dot3(v0, v1), inv_len_product);
@@ -1317,7 +1300,7 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_from_arc(vec3f v0, vec3f v1)
 }
 
 //! make quaternion to rotate 'ang' radians around 'v' vector; v must be normalized
-inline quat4f VECTORCALL v_quat_from_unit_vec_ang(vec3f v, vec4f ang)
+VECTORCALL inline quat4f v_quat_from_unit_vec_ang(vec3f v, vec4f ang)
 {
   vec4f s, c;
   v_sincos4(v_mul(ang, V_C_HALF), s, c);
@@ -1325,7 +1308,7 @@ inline quat4f VECTORCALL v_quat_from_unit_vec_ang(vec3f v, vec4f ang)
 }
 
 // .xyz = heading, attitude, bank
-inline quat4f VECTORCALL v_quat_from_euler(vec3f angles)
+VECTORCALL inline quat4f v_quat_from_euler(vec3f angles)
 {
   vec4f s, c;
   v_sincos4(v_mul(angles, V_C_HALF), s, c);
@@ -1339,7 +1322,7 @@ inline quat4f VECTORCALL v_quat_from_euler(vec3f angles)
 }
 
 // .xyz = heading, attitude, bank
-inline vec3f VECTORCALL v_euler_from_un_quat(quat4f quat)
+VECTORCALL inline vec3f v_euler_from_quat(quat4f quat)
 {
   vec4f test = v_dot2(v_perm_xzxz(quat), v_perm_ywyw(quat));
   vec4f testSign = v_and(test, V_CI_SIGN_MASK);
@@ -1363,7 +1346,7 @@ inline vec3f VECTORCALL v_euler_from_un_quat(quat4f quat)
   return v_sel(angles, specialAngles, specialCase);
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_quat_qslerp(float t, quat4f l, quat4f r)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_qslerp(float t, quat4f l, quat4f r)
 {
   float ca = v_extract_x(v_dot4_x(l, r));
   //todo: vectorize
@@ -1377,7 +1360,7 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_qslerp(float t, quat4f l, quat4f r)
   return v_norm4(v_add(v_mul(l, v_splats(lt)), v_mul(r, v_splats(rt))));
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_quat_qsquad(float t,
+VECTORCALL VECMATH_FINLINE quat4f v_quat_qsquad(float t,
   const quat4f &q0, const quat4f &q1, const quat4f &q2, const quat4f &q3)
 {
   quat4f tmp0, tmp1;
@@ -1386,7 +1369,7 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_qsquad(float t,
   return v_quat_qslerp(2*t*(1-t), tmp0, tmp1);
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_quat_mul_quat(quat4f q1, quat4f q2)
+VECTORCALL VECMATH_FINLINE quat4f v_quat_mul_quat(quat4f q1, quat4f q2)
 {
   vec4f qv, tmp0, tmp1, tmp2, tmp3;
   vec4f product, l_wxyz, r_wxyz, xy, qw;
@@ -1410,7 +1393,7 @@ VECMATH_FINLINE quat4f VECTORCALL v_quat_mul_quat(quat4f q1, quat4f q2)
 //! Decomposes 'q' into a rotational component around 'dir' = twist; and a perpendicular component = swing
 //! q = swing * twist
 //! dir is assumed to be normalized
-VECMATH_FINLINE void VECTORCALL v_quat_decompose_swing_twist(quat4f q, vec3f dir, quat4f& swing, quat4f& twist)
+VECTORCALL VECMATH_FINLINE void v_quat_decompose_swing_twist(quat4f q, vec3f dir, quat4f& swing, quat4f& twist)
 {
   // http://www.euclideanspace.com/maths/geometry/rotations/for/decomposition/
   vec3f p = v_mul(v_dot3(q, dir), dir);
@@ -1421,7 +1404,7 @@ VECMATH_FINLINE void VECTORCALL v_quat_decompose_swing_twist(quat4f q, vec3f dir
 //! Decomposes 'q' into a rotational component around 'dir' = twist; and a perpendicular component = swing
 //! q = twist * swing
 //! dir is assumed to be normalized
-VECMATH_FINLINE void VECTORCALL v_quat_decompose_twist_swing(quat4f q, vec3f dir, quat4f& twist, quat4f& swing)
+VECTORCALL VECMATH_FINLINE void v_quat_decompose_twist_swing(quat4f q, vec3f dir, quat4f& twist, quat4f& swing)
 {
   vec3f p = v_mul(v_dot3(q, dir), dir);
   twist = v_norm4_safe(v_perm_xyzW(p, q));
@@ -1429,7 +1412,7 @@ VECMATH_FINLINE void VECTORCALL v_quat_decompose_twist_swing(quat4f q, vec3f dir
 }
 
 //! make 3x3 rotation matrix from quaternion
-VECMATH_FINLINE void VECTORCALL v_mat33_from_quat(mat33f &dest, quat4f rot)
+VECTORCALL VECMATH_FINLINE void v_mat33_from_quat(mat33f &dest, quat4f rot)
 {
   vec4f xyzw_2, wwww, yzxw, zxyw, yzxw_2, zxyw_2;
   vec4f tmp0, tmp1, tmp2, tmp3, tmp4, tmp5;
@@ -1453,7 +1436,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_from_quat(mat33f &dest, quat4f rot)
 }
 
 //! compose 3x3 matrix from rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat33_compose(mat33f &dest, quat4f rot, vec4f scale)
+VECTORCALL VECMATH_FINLINE void v_mat33_compose(mat33f &dest, quat4f rot, vec4f scale)
 {
   vec4f xyzw_2, wwww, yzxw, zxyw, yzxw_2, zxyw_2;
   vec4f tmp0, tmp1, tmp2, tmp3, tmp4, tmp5;
@@ -1477,7 +1460,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_compose(mat33f &dest, quat4f rot, vec4f 
 }
 
 //! make 4x4 matrix from quaternion and position
-VECMATH_FINLINE void VECTORCALL v_mat44_from_quat(mat44f &dest, quat4f q, vec4f pos)
+VECTORCALL VECMATH_FINLINE void v_mat44_from_quat(mat44f &dest, quat4f q, vec4f pos)
 {
   mat33f m;
   v_mat33_from_quat(m, q);
@@ -1486,7 +1469,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_from_quat(mat44f &dest, quat4f q, vec4f 
 }
 
 //! compose 4x4 matrix from position/rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat44_compose(mat44f &dest, vec4f pos, quat4f rot, vec4f scale)
+VECTORCALL VECMATH_FINLINE void v_mat44_compose(mat44f &dest, vec4f pos, quat4f rot, vec4f scale)
 {
   vec4f xyzw_2, wwww, yzxw, zxyw, yzxw_2, zxyw_2;
   vec4f tmp0, tmp1, tmp2, tmp3, tmp4, tmp5;
@@ -1512,22 +1495,22 @@ VECMATH_FINLINE void VECTORCALL v_mat44_compose(mat44f &dest, vec4f pos, quat4f 
 }
 
 //! decompose 3x3 matrix to rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat33_decompose(mat33f_cref tm, quat4f &rot, vec4f &scl)
+VECTORCALL VECMATH_FINLINE void v_mat33_decompose(mat33f_cref tm, quat4f &rot, vec4f &scl)
 {
   scl = v_mat44_scale43_sq(mat44f{tm.col0, tm.col1, tm.col2});
   scl = v_sqrt4(scl);
   if (v_test_vec_x_lt_0(v_mat33_det(tm)))
     scl = v_perm_xycw(scl, v_neg(scl));
 
-  rot = v_un_quat_from_mat(
-    v_div(tm.col0, v_splat_x(scl)),
-    v_div(tm.col1, v_splat_y(scl)),
-    v_div(tm.col2, v_splat_z(scl)));
-  rot = v_norm4(rot);
+  vec3f invScl = v_rcp_safe(scl);
+  rot = v_quat_from_mat(
+    v_mul(tm.col0, v_splat_x(invScl)),
+    v_mul(tm.col1, v_splat_y(invScl)),
+    v_mul(tm.col2, v_splat_z(invScl)));
 }
 
 //! decompose 4x4 matrix to position/rotation/scale
-VECMATH_FINLINE void VECTORCALL v_mat4_decompose(mat44f_cref tm, vec3f &pos, quat4f &rot, vec4f &scl)
+VECTORCALL VECMATH_FINLINE void v_mat4_decompose(mat44f_cref tm, vec3f &pos, quat4f &rot, vec4f &scl)
 {
   pos = tm.col3;
 
@@ -1536,15 +1519,15 @@ VECMATH_FINLINE void VECTORCALL v_mat4_decompose(mat44f_cref tm, vec3f &pos, qua
   if (v_test_vec_x_lt_0(v_mat44_det43(tm)))
     scl = v_perm_xycw(scl, v_neg(scl));
 
-  rot = v_un_quat_from_mat(
-    v_div(tm.col0, v_splat_x(scl)),
-    v_div(tm.col1, v_splat_y(scl)),
-    v_div(tm.col2, v_splat_z(scl)));
-  rot = v_norm4(rot);
+  vec3f invScl = v_rcp_safe(scl);
+  rot = v_quat_from_mat(
+    v_mul(tm.col0, v_splat_x(invScl)),
+    v_mul(tm.col1, v_splat_y(invScl)),
+    v_mul(tm.col2, v_splat_z(invScl)));
 }
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around 'v'
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw(mat33f &dest, vec3f v, vec4f ang)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw(mat33f &dest, vec3f v, vec4f ang)
 {
   vec4f s, c, oneMinusC, axisS, negAxisS, xxxx, yyyy, zzzz, tmp0, tmp1, tmp2;
   v_sincos4(ang, s, c);
@@ -1568,7 +1551,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw(mat33f &dest, vec3f v, vec4f
 }
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around X axis
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_x(mat33f &dest, vec4f ang)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_x(mat33f &dest, vec4f ang)
 {
   vec4f s, c, res1, res2;
   vec4f select_y = (vec4f)V_CI_MASK0100;
@@ -1582,7 +1565,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_x(mat33f &dest, vec4f ang)
 }
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around Y axis
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_y(mat33f &dest, vec4f ang)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_y(mat33f &dest, vec4f ang)
 {
   vec4f s, c, res0, res2;
   vec4f select_x = (vec4f)V_CI_MASK1000;
@@ -1596,7 +1579,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_y(mat33f &dest, vec4f ang)
 }
 
 //! make rotational matrix 3x3 to rotate 'ang' radians around Z axis
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang)
 {
   vec4f s, c, res0, res1;
   vec4f select_x = (vec4f)V_CI_MASK1000;
@@ -1610,7 +1593,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_z(mat33f &dest, vec4f ang)
 }
 
 //! make composite matrix 3x3: =rot_z(ang.z)*rot_y(ang.y)*rot_x(ang.x)
-VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_xyz)
+VECTORCALL VECMATH_FINLINE void v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_xyz)
 {
   vec4f s, negS, c, X0, X1, Y0, Y1, Z0, Z1, tmp;
   v_sincos4(v_and(ang_xyz, (vec4f)V_CI_MASK1110), s, c);
@@ -1628,9 +1611,9 @@ VECMATH_FINLINE void VECTORCALL v_mat33_make_rot_cw_zyx(mat33f &dest, vec4f ang_
   dest.col2 = v_nmsub(Z1, X0, v_mul(tmp, X1));
 }
 
-VECMATH_FINLINE plane3f VECTORCALL v_norm_plane(plane3f in) { return v_norm3(in); }
+VECTORCALL VECMATH_FINLINE plane3f v_norm_plane(plane3f in) { return v_norm3(in); }
 
-VECMATH_FINLINE vec3f VECTORCALL v_ray_intersect_plane(vec3f A, vec3f B, plane3f P, vec4f &behind, vec4f &t)
+VECTORCALL VECMATH_FINLINE vec3f v_ray_intersect_plane(vec3f A, vec3f B, plane3f P, vec4f &behind, vec4f &t)
 {
   vec3f dir = v_sub(B, A);
   vec4f dot = v_dot3(dir, P);
@@ -1639,11 +1622,11 @@ VECMATH_FINLINE vec3f VECTORCALL v_ray_intersect_plane(vec3f A, vec3f B, plane3f
   return v_madd(t, dir, A);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL three_plane_intersection(plane3f p0, plane3f p1, plane3f p2, vec4f &invalid)
+VECTORCALL VECMATH_FINLINE vec3f three_plane_intersection(plane3f p0, plane3f p1, plane3f p2, vec4f &invalid)
 {
   vec4f n1_n2 = v_cross3(p1, p2), n2_n0 = v_cross3(p2, p0), n0_n1 = v_cross3(p0, p1);
   vec4f cosTheta = v_dot3(p0, n1_n2);
-  invalid = v_cmp_lt(v_abs(cosTheta), V_C_VERY_SMALL_VAL);
+  invalid = v_is_unsafe_divisor(cosTheta);
   vec4f secTheta = v_rcp(cosTheta);
 
   vec4f intersectPt;
@@ -1653,7 +1636,7 @@ VECMATH_FINLINE vec3f VECTORCALL three_plane_intersection(plane3f p0, plane3f p1
   return v_mul(intersectPt, secTheta);
 }
 
-VECMATH_FINLINE void VECTORCALL v_unsafe_two_plane_intersection(plane3f p1, plane3f p2, vec3f &point, vec3f &dir)
+VECTORCALL VECMATH_FINLINE void v_unsafe_two_plane_intersection(plane3f p1, plane3f p2, vec3f &point, vec3f &dir)
 {
   dir = v_cross3(p1, p2);//p3_normal
   // calculate the final (point, normal)
@@ -1663,14 +1646,14 @@ VECMATH_FINLINE void VECTORCALL v_unsafe_two_plane_intersection(plane3f p1, plan
   point = v_div(point, v_dot3(dir, dir));
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_unsafe_ray_intersect_plane(vec3f point, vec3f dir, plane3f P)
+VECTORCALL VECMATH_FINLINE vec3f v_unsafe_ray_intersect_plane(vec3f point, vec3f dir, plane3f P)
 {
   vec3f t = v_div(v_sub(v_neg(v_splat_w(P)), v_dot3(point, P)), v_dot3(dir, P));
   //for safe check if abs(v_dot3(dir, P)) is bigger than eps
   return v_madd(t, dir, point);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL closest_point_on_segment(vec3f point, vec3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec3f closest_point_on_segment(vec3f point, vec3f a, vec3f b)
 {
   vec3f ap = v_sub(point, a);
   vec3f ab = v_sub(b, a);
@@ -1679,7 +1662,7 @@ VECMATH_FINLINE vec3f VECTORCALL closest_point_on_segment(vec3f point, vec3f a, 
   return v_madd(v_safediv(ab, lenSq), t, a);
 }
 
-VECMATH_FINLINE void VECTORCALL vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, vec4f z, mat44f_cref mat)
+VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, vec4f z, mat44f_cref mat)
 {
 #define COMP(c, attr) \
   vec4f res_ ## c = v_splat_##attr(mat.col3); \
@@ -1694,7 +1677,7 @@ VECMATH_FINLINE void VECTORCALL vis_transform_points_4(vec4f* dest, vec4f x, vec
 #undef COMP
 }
 
-VECMATH_FINLINE void VECTORCALL vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, mat44f_cref mat)
+VECTORCALL VECMATH_FINLINE void vis_transform_points_4(vec4f* dest, vec4f x, vec4f y, mat44f_cref mat)
 {
 #define COMP(c, attr) \
   vec4f res_ ## c = v_splat_##attr(mat.col3); \
@@ -1709,15 +1692,15 @@ VECMATH_FINLINE void VECTORCALL vis_transform_points_4(vec4f* dest, vec4f x, vec
 }
 
 #if _TARGET_SIMD_SSE
-VECMATH_FINLINE int VECTORCALL v_test_vec_mask_eq_0(vec4f v) { return (~unsigned(-_mm_movemask_ps(v))) >> 31; }
-VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v) { return (unsigned(-_mm_movemask_ps(v))) >> 31; }
+VECTORCALL VECMATH_FINLINE int v_test_vec_mask_eq_0(vec4f v) { return (~unsigned(-_mm_movemask_ps(v))) >> 31; }
+VECTORCALL VECMATH_FINLINE int v_test_vec_mask_neq_0(vec4f v) { return (unsigned(-_mm_movemask_ps(v))) >> 31; }
 #else
-VECMATH_FINLINE int VECTORCALL v_test_vec_mask_eq_0(vec4f v)
+VECTORCALL VECMATH_FINLINE int v_test_vec_mask_eq_0(vec4f v)
 {
   return v_test_vec_x_eqi_0(v_cast_vec4f(v_srli(v_cast_vec4i(v_hor(v)), 31)));
 }
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v)
+VECTORCALL VECMATH_FINLINE int v_test_vec_mask_neq_0(vec4f v)
 {
   return !v_test_vec_mask_eq_0(v);
 }
@@ -1729,7 +1712,7 @@ VECMATH_FINLINE int VECTORCALL v_test_vec_mask_neq_0(vec4f v)
 ///really fast, ~0.075 us per test on PS3
 
 ///for branching: (~v_test_vec_x_eqi_0(v_is_visible(bmin, bmax, clip)))&1 will be 1 if visible, zero otherwise;
-VECMATH_FINLINE vec4f VECTORCALL v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE vec4f v_is_visible(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f zero = v_zero();
 
@@ -1775,7 +1758,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_is_visible(vec3f bmin, vec3f bmax, mat44f_cre
 }
 
 #if _TARGET_SIMD_SSE
-VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   // get aabb points (SoA)
   vec4f minmax_x = v_perm_xXxX(bmin, bmax);
@@ -1810,14 +1793,14 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cre
   return nout>>31;
 }
 #else
-VECMATH_FINLINE int VECTORCALL v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_is_visible_b(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f ret = v_is_visible(bmin, bmax, clip);
   return (~v_test_vec_x_eqi_0(ret))&1;
 }
 #endif
 
-VECMATH_FINLINE void VECTORCALL v_construct_camplanes(mat44f_cref clip,
+VECTORCALL VECMATH_FINLINE void v_construct_camplanes(mat44f_cref clip,
   vec4f &camPlanes0, vec4f &camPlanes1, vec4f &camPlanes2, vec4f &camPlanes3, vec4f &camPlanes4, vec4f &camPlanes5)
 {
   mat44f m2;
@@ -1830,7 +1813,7 @@ VECMATH_FINLINE void VECTORCALL v_construct_camplanes(mat44f_cref clip,
   camPlanes5 = m2.col2;  // near if forward depth (far otherwise)
 }
 
-VECMATH_FINLINE void VECTORCALL v_frustum_box_unsafe(bbox3f& box,
+VECTORCALL VECMATH_FINLINE void v_frustum_box_unsafe(bbox3f& box,
                                  vec4f camPlanes0, vec4f camPlanes1, vec4f camPlanes2,
                                  const vec4f &camPlanes3, const vec4f &camPlanes4, const vec4f &camPlanes5)
 {
@@ -1845,7 +1828,7 @@ VECMATH_FINLINE void VECTORCALL v_frustum_box_unsafe(bbox3f& box,
   v_bbox3_add_pt(box, three_plane_intersection(camPlanes4, camPlanes3, camPlanes0, invalid));
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane4, const vec4f& plane5)
 {
@@ -1860,7 +1843,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
   return v_test_vec_mask_eq_0(res03);
 }
 
-VECMATH_FINLINE int VECTORCALL v_sphere_intersect(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
                   vec3f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane4, const vec4f& plane5)
 {
@@ -1885,7 +1868,7 @@ VECMATH_FINLINE int VECTORCALL v_sphere_intersect(vec3f center, vec3f r,
   return v_test_vec_mask_neq_0(res03) + 1;
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_box_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_is_visible_box_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2,
                   const vec4f& plane4W2, const vec4f& plane5W2)
 {
@@ -1900,7 +1883,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_box_extent2(vec3f center, vec3f exte
   return v_test_vec_mask_eq_0(res03);
 }
 
-VECMATH_FINLINE int VECTORCALL v_box_frustum_intersect_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2,
                   const vec4f& plane4W2, const vec4f& plane5W2)
 {
@@ -1924,7 +1907,7 @@ VECMATH_FINLINE int VECTORCALL v_box_frustum_intersect_extent2(vec3f center, vec
   return v_test_vec_mask_neq_0(res03) + 1;
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_extent_fast(vec3f center, vec3f extent, mat44f_cref clip)//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast(vec3f center, vec3f extent, mat44f_cref clip)//center and extent should be multiplied by 2
 {
   //construct frustum
   vec3f plane03X, plane03Y, plane03Z, plane03W2, plane4W2, plane5W2;
@@ -1938,7 +1921,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_extent_fast(vec3f center, vec3f exte
   return v_is_visible_box_extent2(center, extent, plane03X, plane03Y, plane03Z, plane03W2, plane4W2, plane5W2);
 }
 
-VECMATH_FINLINE int VECTORCALL v_frustum_intersect(vec3f center, vec3f extent, mat44f_cref clip)//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_frustum_intersect(vec3f center, vec3f extent, mat44f_cref clip)//center and extent should be multiplied by 2
 {
   //construct frustum
   vec3f plane03X, plane03Y, plane03Z, plane03W2, plane4W2, plane5W2;
@@ -1951,14 +1934,14 @@ VECMATH_FINLINE int VECTORCALL v_frustum_intersect(vec3f center, vec3f extent, m
   return v_box_frustum_intersect_extent2(center, extent, plane03X, plane03Y, plane03Z, plane03W2, plane4W2, plane5W2);
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_b_fast(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_is_visible_b_fast(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f center = v_add(bmax, bmin);
   vec4f extent = v_sub(bmax, bmin);
   return v_is_visible_extent_fast(center, extent, clip);
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_box_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_is_visible_box_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2,
                   const vec4f& plane47X, const vec4f& plane47Y, const vec4f& plane47Z, const vec4f& plane47W2)
 {
@@ -1976,7 +1959,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_box_extent2(vec3f center, vec3f exte
   return (~unsigned(-result))>>31;
 }
 
-VECMATH_FINLINE int VECTORCALL v_box_frustum_intersect_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
+VECTORCALL VECMATH_FINLINE int v_box_frustum_intersect_extent2(vec3f center, vec3f extent,//center and extent should be multiplied by 2
                   vec4f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W2,
                   const vec4f& plane47X, const vec4f& plane47Y, const vec4f& plane47Z, const vec4f& plane47W2)
 {
@@ -2029,7 +2012,7 @@ VECMATH_FINLINE int VECTORCALL v_box_frustum_intersect_extent2(vec3f center, vec
   //*/
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_is_visible_sphere(vec3f center, vec3f r,
                   vec3f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane47X, const vec4f& plane47Y, const vec4f& plane47Z, const vec4f& plane47W)
 {
@@ -2045,7 +2028,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_sphere(vec3f center, vec3f r,
   return (~unsigned(-result))>>31;
 }
 
-VECMATH_FINLINE int VECTORCALL v_sphere_intersect(vec3f center, vec3f r,
+VECTORCALL VECMATH_FINLINE int v_sphere_intersect(vec3f center, vec3f r,
                   vec3f plane03X, const vec4f& plane03Y, const vec4f& plane03Z, const vec4f& plane03W,
                   const vec4f& plane47X, const vec4f& plane47Y, const vec4f& plane47Z, const vec4f& plane47W)
 {
@@ -2066,7 +2049,7 @@ VECMATH_FINLINE int VECTORCALL v_sphere_intersect(vec3f center, vec3f r,
   return ((unsigned(-result))>>31) + 1;
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_extent_fast_8planes(vec3f center, vec3f extent, mat44f_cref clip)//just correct box extents, not multiplied
+VECTORCALL VECMATH_FINLINE int v_is_visible_extent_fast_8planes(vec3f center, vec3f extent, mat44f_cref clip)//just correct box extents, not multiplied
 {
   //construct frustum
   vec3f plane03X, plane03Y, plane03Z, plane03W, plane47X, plane47Y, plane47Z, plane47W;
@@ -2078,7 +2061,7 @@ VECMATH_FINLINE int VECTORCALL v_is_visible_extent_fast_8planes(vec3f center, ve
   return v_is_visible_box_extent2(center, extent, plane03X, plane03Y, plane03Z, plane03W, plane47X, plane47Y, plane47Z, plane47W);
 }
 
-VECMATH_FINLINE int VECTORCALL v_is_visible_b_fast_8planes(vec3f bmin, vec3f bmax, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_is_visible_b_fast_8planes(vec3f bmin, vec3f bmax, mat44f_cref clip)
 {
   vec4f center = v_mul(v_add(bmax, bmin), V_C_HALF);
   vec4f extent = v_sub(bmax, center);
@@ -2094,7 +2077,7 @@ alignas(16) static float v_screen_div_eps[4] = {0.0001f,0.0001f,0.0001f,0.0001f}
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. not zero, otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
 
-VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
 {
   // get aabb points (SoA)
   vec4f minmax_x = v_perm_xXxX(bmin, bmax);
@@ -2199,7 +2182,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f bmin, vec3f bmax, vec3f thr
 
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. 1, if all vertex are in front of near plane, -1 (and fullscreen rect) otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1), minmax_w is wWwW (minw, maxw, minw, maxw)
-VECMATH_FINLINE int VECTORCALL
+VECTORCALL VECMATH_FINLINE int
   v_screen_size_b(vec3f bmin, vec3f bmax, vec3f threshold, vec4f &screen_box, vec4f &minmax_w, mat44f_cref clip)
 {
   // get aabb points (SoA)
@@ -2306,7 +2289,7 @@ VECMATH_FINLINE int VECTORCALL
 ///return zero if not visible in frustum or if bbox screen size is smaller, than threshold. not zero, otherwise
 // also, screen_box is minX, maxX, minY, maxY - in clipspace coordinates  (-1, -1) .. (1,1)
 
-VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f box2_xyXY, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
+VECTORCALL VECMATH_FINLINE int v_screen_size_b(vec3f box2_xyXY, vec3f threshold, vec4f &screen_box, mat44f_cref clip)
 {
   // get aabb points (SoA)
   vec4f minmax_x = v_perm_xzxz(box2_xyXY);
@@ -2402,7 +2385,7 @@ VECMATH_FINLINE int VECTORCALL v_screen_size_b(vec3f box2_xyXY, vec3f threshold,
 //.x - closest dist (tmin), .y farthest dist (tmax)
 // both can be negative
 // ray intersects box if tmax >= max(ray.tmin, tmin) && tmin < ray.tmax
-VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist_est(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box)
+VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist_est(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box)
 {
   vec3f invRay = v_rcp_est(ray_dir);//we can't use 1/x or v_rcp, as we have to ensure that invRay has infs if rayDir is 0 in some direction
   vec3f firstPlaneIntersect  = v_mul(v_sub(bmin, ray_origin), invRay);
@@ -2417,9 +2400,9 @@ VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist_est(vec3f bmin, vec3f b
 //.x - closest dist (tmin), .y farthest dist (tmax)
 // both can be negative
 // ray intersects box if tmax >= max(ray.tmin, tmin) && tmin <= ray.tmax
-VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box)
+VECTORCALL VECMATH_INLINE  vec4f v_ray_box_intersect_dist(vec3f bmin, vec3f bmax, vec3f ray_origin, vec3f ray_dir, vec3f is_empty_box)
 {
-  vec3f invRay = v_rcp_safe(ray_dir, V_C_INF);
+  vec3f invRay = v_rcp_safe(ray_dir, V_C_MAX_VAL);
   vec3f firstPlaneIntersect = v_mul(v_sub(bmin, ray_origin), invRay);
   vec3f secondPlaneIntersect = v_mul(v_sub(bmax, ray_origin), invRay);
   vec3f furthestPlane = v_max(firstPlaneIntersect, secondPlaneIntersect);
@@ -2430,7 +2413,7 @@ VECMATH_INLINE vec4f VECTORCALL v_ray_box_intersect_dist(vec3f bmin, vec3f bmax,
 }
 
 // test that tmax_x intersect segment [lmin; lmax] and update it to max(0, lmin) if yes
-VECMATH_INLINE bool VECTORCALL v_segment_test_internal(vec3f lmin_lmax, vec3f& tmax_x)
+VECTORCALL VECMATH_INLINE  bool v_segment_test_internal(vec3f lmin_lmax, vec3f& tmax_x)
 {
   vec4f clampedMin = v_max(lmin_lmax, v_zero());
   vec4f isect = v_and(v_cmp_ge(v_splat_y(lmin_lmax), clampedMin), v_cmp_ge(tmax_x, lmin_lmax));
@@ -2438,40 +2421,40 @@ VECMATH_INLINE bool VECTORCALL v_segment_test_internal(vec3f lmin_lmax, vec3f& t
   return v_extract_xi(v_cast_vec4i(isect)) != 0;
 }
 
-VECMATH_INLINE bool VECTORCALL v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
+VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
 {
   vec3f isEmptyBox = v_cmp_gt(box.bmin, box.bmax);
   vec4f at = v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox);
   return v_segment_test_internal(at, t_x);
 }
 
-VECMATH_INLINE bool VECTORCALL v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
+VECTORCALL VECMATH_INLINE  bool v_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f &t_x, bbox3f box)
 {
   vec3f isEmptyBox = v_zero();
   vec4f at = v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox);
   return v_segment_test_internal(at, t_x);
 }
 
-VECMATH_INLINE bool VECTORCALL v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
+VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
 {
   vec3f isEmptyBox = v_cmp_gt(box.bmin, box.bmax);
   return v_segment_test_internal(v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox), len_x);
 }
 
-VECMATH_INLINE bool VECTORCALL v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
+VECTORCALL VECMATH_INLINE  bool v_test_ray_box_intersection_unsafe(vec3f start, vec3f dir, vec3f len_x, bbox3f box)
 {
   vec3f isEmptyBox = v_zero();
   return v_segment_test_internal(v_ray_box_intersect_dist(box.bmin, box.bmax, start, dir, isEmptyBox), len_x);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f box)
+VECTORCALL VECMATH_FINLINE bool v_test_segment_box_intersection(vec3f start, vec3f end, bbox3f box)
 {
   vec4f t = V_C_ONE;
   return v_test_ray_box_intersection(start, v_sub(end, start), t, box);
 }
 
 // return -1 if no intersection found, or box side index in [0; 5] and output param 'at' in range [0.0; 1.0]
-inline int VECTORCALL v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at)
+VECTORCALL inline int v_segment_box_intersection_side(vec3f start, vec3f end, bbox3f box, float& out_at)
 {
   int ret = -1;
   vec3f fullDir = v_sub(end, start);
@@ -2541,7 +2524,7 @@ inline int VECTORCALL v_segment_box_intersection_side(vec3f start, vec3f end, bb
   return ret;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_ray_sphere_intersection(vec3f p0,
+VECTORCALL VECMATH_FINLINE bool v_test_ray_sphere_intersection(vec3f p0,
                                                                vec3f dir,
                                                                vec4f len,
                                                                vec4f sphere_center,
@@ -2552,7 +2535,7 @@ VECMATH_FINLINE bool VECTORCALL v_test_ray_sphere_intersection(vec3f p0,
   return v_test_vec_x_le(v_length3_sq(v_sub(v_mul(dir, t), ap)), sphere_r2_x);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_segment_sphere_intersection(vec3f p0,
+VECTORCALL VECMATH_FINLINE bool v_test_segment_sphere_intersection(vec3f p0,
                                                                    vec3f p1,
                                                                    vec3f sphere_center,
                                                                    vec4f sphere_r2_x)
@@ -2595,12 +2578,12 @@ VECMATH_FINLINE bool v_ray_sphere_intersection(vec3f start, vec3f dir, vec4f &t_
 }
 
 #if !_TARGET_SIMD_SSE
-VECMATH_FINLINE void VECTORCALL v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm)
+VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f &tm)
 {
   v_mat_43cu_from_mat44(m43, tm);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm)
+VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f &tm)
 {
   v_stu_p3(m43 + 0, tm.col0);
   v_stu_p3(m43 + 3, tm.col1);
@@ -2609,7 +2592,7 @@ VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, co
 }
 
 //mat44f from unaligned TMatrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f &tmV, const float *const __restrict m43)
 {
   tmV.col0 = v_and(v_ldu(m43+0), (vec4f)V_CI_MASK1110);
   tmV.col1 = v_and(v_ldu(m43+3), (vec4f)V_CI_MASK1110);
@@ -2618,7 +2601,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f &tmV, const float 
 }
 
 //mat44f from aligned TMatrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f &tmV, const float *const __restrict m43)
 {
   tmV.col0 = v_and(v_ld(m43+0), (vec4f)V_CI_MASK1110);
   tmV.col1 = v_and(v_ldu(m43+3), (vec4f)V_CI_MASK1110);
@@ -2627,7 +2610,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f &tmV, const float 
 }
 #endif // !_TARGET_SIMD_SSE
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu_unsafe(mat44f &tmV, const float *const __restrict m43)
 {
   vec4f v0 = v_ldu(m43 + 0);
   vec4f v1 = v_ldu(m43 + 4);
@@ -2638,7 +2621,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu_unsafe(mat44f &tmV, const
   tmV.col3 = v_rot_1(v2);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat_44cu_from_mat44(float* __restrict m44, const mat44f& tm)
+VECTORCALL VECMATH_FINLINE void v_mat_44cu_from_mat44(float* __restrict m44, const mat44f& tm)
 {
   v_stu(m44 + 0, tm.col0);
   v_stu(m44 + 4, tm.col1);
@@ -2647,7 +2630,7 @@ VECMATH_FINLINE void VECTORCALL v_mat_44cu_from_mat44(float* __restrict m44, con
 }
 
 //mat44f from unaligned 4x4 matrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_44cu(mat44f &tmV, const float *const __restrict m44)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_44cu(mat44f &tmV, const float *const __restrict m44)
 {
   tmV.col0 = v_ldu(m44+0);
   tmV.col1 = v_ldu(m44+4);
@@ -2656,7 +2639,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_44cu(mat44f &tmV, const float 
 }
 
 //mat44f from aligned 4x4 matrix
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_44ca(mat44f &tmV, const float *const __restrict m44)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_44ca(mat44f &tmV, const float *const __restrict m44)
 {
   tmV.col0 = v_ld(m44+0);
   tmV.col1 = v_ld(m44+4);
@@ -2664,11 +2647,11 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_44ca(mat44f &tmV, const float 
   tmV.col3 = v_ld(m44+12);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_div_est(vec4f a, vec4f b) {return v_mul(a, v_rcp_est(b));}
+VECTORCALL VECMATH_FINLINE vec4f v_div_est(vec4f a, vec4f b) {return v_mul(a, v_rcp_est(b));}
 #if _TARGET_SIMD_SSE
-VECMATH_FINLINE vec4f VECTORCALL is_neg_special(vec4f a) {return v_cast_vec4f(v_srai(v_cast_vec4i(a), 31));}
+VECTORCALL VECMATH_FINLINE vec4f is_neg_special(vec4f a) {return v_cast_vec4f(v_srai(v_cast_vec4i(a), 31));}
 #else
-VECMATH_FINLINE vec4f VECTORCALL is_neg_special(vec4f a) {vec4f msbit = v_msbit(); return v_cmp_eqi(v_and(a, msbit), msbit);}
+VECTORCALL VECMATH_FINLINE vec4f is_neg_special(vec4f a) {vec4f msbit = v_msbit(); return v_cmp_eqi(v_and(a, msbit), msbit);}
 #endif
 
 #define POLY0(x, c0) v_splats(c0)
@@ -2688,33 +2671,33 @@ VECMATH_FINLINE vec4f VECTORCALL is_neg_special(vec4f a) {vec4f msbit = v_msbit(
    expipart = v_cast_vec4f(v_slli(v_addi(ipart, v_splatsi(127)), 23));\
 
    /* minimax polynomial fit of 2**x, in range [-0.5, 0.5[ */
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p5(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p5(vec4f x)
 {
   EXP_DEF_PART
   expfpart = POLY5(fpart, 9.9999994e-1f, 6.9315308e-1f, 2.4015361e-1f, 5.5826318e-2f, 8.9893397e-3f, 1.8775767e-3f);
   return v_mul(expipart, expfpart);
 }
 
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p4(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p4(vec4f x)
 {
   EXP_DEF_PART
   expfpart = POLY4(fpart, 1.0000026f, 6.9300383e-1f, 2.4144275e-1f, 5.2011464e-2f, 1.3534167e-2f);
   return v_mul(expipart, expfpart);
 }
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p3(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p3(vec4f x)
 {
   EXP_DEF_PART
   expfpart = POLY3(fpart, 9.9992520e-1f, 6.9583356e-1f, 2.2606716e-1f, 7.8024521e-2f);
   return v_mul(expipart, expfpart);
 }
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est_p2(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est_p2(vec4f x)
 {
   EXP_DEF_PART
   expfpart = POLY2(fpart, 1.0017247f, 6.5763628e-1f, 3.3718944e-1f);
   return v_mul(expipart, expfpart);
 }
 
-VECMATH_INLINE vec4f VECTORCALL v_exp2(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_exp2(vec4f x)
 {
   vec4i ipart;
   vec4f fpart, expipart, expfpart;
@@ -2737,7 +2720,7 @@ VECMATH_INLINE vec4f VECTORCALL v_exp2(vec4f x)
    vec4f m = v_or(v_cast_vec4f(v_andi(i, mant)), V_C_ONE);\
    vec4f p;
 
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p5(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p5(vec4f x)
 {
    LOG_DEF_PART
    p = POLY5( m, 3.1157899f, -3.3241990f, 2.5988452f, -1.2315303f,  3.1821337e-1f, -3.4436006e-2f);
@@ -2745,20 +2728,20 @@ VECMATH_INLINE vec4f VECTORCALL v_log2_est_p5(vec4f x)
    return v_add(v_mul(p, v_sub(m, V_C_ONE)), e);
 }
 
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p4(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p4(vec4f x)
 {
    LOG_DEF_PART
    p = POLY4(m, 2.8882704548164776201f, -2.52074962577807006663f,
                 1.48116647521213171641f, -0.465725644288844778798f, 0.0596515482674574969533f);
    return v_add(v_mul(p, v_sub(m, V_C_ONE)), e);
 }
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p3(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p3(vec4f x)
 {
    LOG_DEF_PART
    p = POLY3(m, 2.61761038894603480148f, -1.75647175389045657003f, 0.688243882994381274313f, -0.107254423828329604454f);
    return v_add(v_mul(p, v_sub(m, V_C_ONE)), e);
 }
-VECMATH_INLINE vec4f VECTORCALL v_log2_est_p2(vec4f x)
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est_p2(vec4f x)
 {
    LOG_DEF_PART
    p = POLY2(m, 2.28330284476918490682f, -1.04913055217340124191f, 0.204446009836232697516f);
@@ -2767,19 +2750,19 @@ VECMATH_INLINE vec4f VECTORCALL v_log2_est_p2(vec4f x)
 
 #undef LOG_DEF_PART
 
-VECMATH_INLINE vec4f VECTORCALL v_exp2_est(vec4f x) {return v_exp2_est_p4(x);}
-VECMATH_INLINE vec4f VECTORCALL v_log2_est(vec4f x) {return v_log2_est_p4(x);}
+VECTORCALL VECMATH_INLINE  vec4f v_exp2_est(vec4f x) {return v_exp2_est_p4(x);}
+VECTORCALL VECMATH_INLINE  vec4f v_log2_est(vec4f x) {return v_log2_est_p4(x);}
 
-VECMATH_FINLINE vec4f VECTORCALL v_pow_est(vec4f x, vec4f y)
+VECTORCALL VECMATH_FINLINE vec4f v_pow_est(vec4f x, vec4f y)
 {
    return v_exp2_est_p4(v_mul(v_log2_est_p5(x), y));
 }
 //natural log
-VECMATH_FINLINE vec4f VECTORCALL v_log(vec4f x){return v_mul(v_log2_est_p5(x), v_splats(0.6931471805599453f));}
+VECTORCALL VECMATH_FINLINE vec4f v_log(vec4f x){return v_mul(v_log2_est_p5(x), v_splats(0.6931471805599453f));}
 //natural exponent
-VECMATH_FINLINE vec4f VECTORCALL v_exp(vec4f x){return v_exp2(v_mul(x, v_splats(1.4426950408889634073599f)));}//log2(e)
+VECTORCALL VECMATH_FINLINE vec4f v_exp(vec4f x){return v_exp2(v_mul(x, v_splats(1.4426950408889634073599f)));}//log2(e)
 //safer pow. checks for y == 0
-VECMATH_FINLINE vec4f VECTORCALL v_pow(vec4f x, vec4f y)
+VECTORCALL VECMATH_FINLINE vec4f v_pow(vec4f x, vec4f y)
 {
    vec4f ret = v_exp2(v_mul(v_log2_est_p5(x), y));
    ret = v_sel(ret, V_C_ONE, v_cmp_eq(y, v_zero()));
@@ -2793,62 +2776,62 @@ VECMATH_FINLINE vec4f VECTORCALL v_pow(vec4f x, vec4f y)
 #undef POLY4
 #undef POLY5
 
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane_dir(vec3f p0, vec3f dir0, vec3f dir1)
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane_dir(vec3f p0, vec3f dir0, vec3f dir1)
 {
   vec3f n = v_cross3(dir0, dir1);
   return v_make_plane_norm(p0, n);
 }
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane(vec3f p0, vec3f p1, vec3f p2)
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane(vec3f p0, vec3f p1, vec3f p2)
 {
   return v_make_plane_dir(p0, v_sub(p1,p0), v_sub(p2, p0));
 }
 
-VECMATH_FINLINE plane3f VECTORCALL v_make_plane_norm(vec3f p0, vec3f norm)
+VECTORCALL VECMATH_FINLINE plane3f v_make_plane_norm(vec3f p0, vec3f norm)
 {
   vec3f d = v_neg(v_dot3(norm, p0));
   return v_perm_xyzd(norm, d);
 }
 
-VECMATH_FINLINE plane3f VECTORCALL v_transform_plane(plane3f plane, mat44f_cref transform)
+VECTORCALL VECMATH_FINLINE plane3f v_transform_plane(plane3f plane, mat44f_cref transform)
 {
   // simple way
   vec3f p0 = v_mul(plane, v_neg(v_splat_w(plane))); // p0 = norm * -d
   return v_make_plane_norm(v_mat44_mul_vec3p(transform, p0), v_mat44_mul_vec3v(transform, plane));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c)
 {
   vec4f diff = v_max(v_max(v_sub(bmin, c), v_sub(c, bmax)), v_zero());
   return v_dot3_x(diff, diff);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_to_bbox_2d_x(vec4f bmin, vec4f bmax, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_to_bbox_2d_x(vec4f bmin, vec4f bmax, vec4f c)
 {
   vec4f diff = v_max(v_max(v_sub(bmin, c), v_sub(c, bmax)), v_zero());
   vec3f diffSq = v_mul(diff, diff);
   return v_add_x(diffSq, v_splat_z(diffSq));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_box_to_box_x(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB)
 {
   vec3f axisDistances = v_max(v_sub(v_abs(v_sub(centerB, centerA)), v_add(extentA, extentB)), v_zero());
   return v_dot3_x(axisDistances, axisDistances);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_distance_sq_box_to_box_x_scaled(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB, vec3f scale)
+VECTORCALL VECMATH_FINLINE vec4f v_distance_sq_box_to_box_x_scaled(vec3f centerA, vec3f extentA, vec3f centerB, vec3f extentB, vec3f scale)
 {
   vec3f axisDistances = v_max(v_sub(v_abs(v_sub(centerB, centerA)), v_add(extentA, extentB)), v_zero());
   axisDistances = v_mul(axisDistances, scale);
   return v_dot3_x(axisDistances, axisDistances);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_max_dist_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_max_dist_sq_to_bbox_x(vec4f bmin, vec4f bmax, vec4f c)
 {
   vec4f diff = v_max(v_max(v_sub(c, bmin), v_sub(bmax, c)), v_zero());
   return v_dot3_x(diff, diff);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_closest_bbox_point(vec3f bmin, vec3f bmax, vec3f c)
+VECTORCALL VECMATH_FINLINE vec3f v_closest_bbox_point(vec3f bmin, vec3f bmax, vec3f c)
 {
   c = v_sel(c, bmin, v_cmp_gt(bmin, c));
   c = v_sel(c, bmax, v_cmp_gt(c, bmax));
@@ -2857,20 +2840,20 @@ VECMATH_FINLINE vec3f VECTORCALL v_closest_bbox_point(vec3f bmin, vec3f bmax, ve
 
 
 //returns point on infinite line which is closes to point
-VECMATH_FINLINE vec3f VECTORCALL closest_point_on_line(vec3f point, vec3f a, vec3f dir)
+VECTORCALL VECMATH_FINLINE vec3f closest_point_on_line(vec3f point, vec3f a, vec3f dir)
 {
   vec3f t = v_dot3(v_sub(point, a), dir);// t param along line
   return v_madd(dir, t, a);//pt is point on line
 }
 
-VECMATH_FINLINE vec4f VECTORCALL distance_to_line_x(vec3f point, vec3f a, vec3f dir)
+VECTORCALL VECMATH_FINLINE vec4f distance_to_line_x(vec3f point, vec3f a, vec3f dir)
 {
   vec3f pa = v_sub(point, a);
   vec3f t = v_dot3(pa, dir);// t param along line
   return v_length3_x(v_sub(pa, v_mul(dir, t)));
 };
 
-VECMATH_FINLINE vec4f VECTORCALL distance_to_seg_x(vec3f point, vec3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec4f distance_to_seg_x(vec3f point, vec3f a, vec3f b)
 {
   vec3f pt = closest_point_on_segment(point, a, b);
   return v_length3_x(v_sub(point, pt));
@@ -2881,7 +2864,7 @@ VECMATH_FINLINE vec4f VECTORCALL distance_to_seg_x(vec3f point, vec3f a, vec3f b
 //https://gist.github.com/rygorous/2156668
 
 //doesn't round correctly
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half(vec4f f)
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half(vec4f f)
 {
   vec4i mask_fabs  = v_splatsi(0x7fffffff);
   vec4i c_f16max   = v_splatsi((127 + 16) << 23);
@@ -2906,7 +2889,7 @@ VECMATH_FINLINE vec4i VECTORCALL v_float_to_half(vec4f f)
 
 //handles infs/nans, doesn't round correctly
 //it (incorrectly) translates some of sNaNs into infinity, so be careful!
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_specials(vec4f f)
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_specials(vec4f f)
 {
   vec4i mask_fabs  = v_splatsi(0x7fffffff);
   vec4i c_f32infty = v_splatsi((255 << 23));
@@ -2936,7 +2919,7 @@ VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_specials(vec4f f)
 }
 
 // round-to-nearest-even, doesn't handle nans
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_rtne(vec4f f)
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_rtne(vec4f f)
 {
   vec4i mask_sign       = v_splatsi(0x80000000u);
   vec4i c_f16max        = v_splatsi((127 + 16) << 23); // all FP32 values >=this round to +inf
@@ -2982,13 +2965,13 @@ VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_rtne(vec4f f)
   return final;
 }
 
-VECMATH_FINLINE void VECTORCALL v_float_to_half(uint16_t* __restrict m, const vec4f v)
+VECTORCALL VECMATH_FINLINE void v_float_to_half(uint16_t* __restrict m, const vec4f v)
 {
   v_stui_half(m, v_packus(v_float_to_half(v)));
 }
 
 
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float(vec4i h)
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float(vec4i h)
 {
   const vec4f magic = v_cast_vec4f(v_splatsi((254 - 15) << 23));
   vec4i oi = v_srl(v_sll(h, 17), 4); // exponent/mantissa bits
@@ -2996,7 +2979,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_half_to_float(vec4i h)
   return v_or(of, v_cast_vec4f(v_sll(v_srl(h, 15), 31)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float_specials(vec4i h)
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float_specials(vec4i h)
 {
   const vec4f magic = v_cast_vec4f(v_splatsi((254 - 15) << 23));
   const vec4f was_infnan = v_cast_vec4f(v_splatsi((127 + 16) << 23));
@@ -3007,7 +2990,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_half_to_float_specials(vec4i h)
 }
 
 //not checking for NANs
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_up(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_up(vec4f a)
 {
   vec4i c = v_float_to_half(a);
   vec4f incMask = v_cmp_lt(v_half_to_float(c), a);
@@ -3015,19 +2998,19 @@ VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_up(vec4f a)
 }
 
 //not checking for NANs
-VECMATH_FINLINE vec4i VECTORCALL v_float_to_half_down(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_float_to_half_down(vec4f a)
 {
   vec4i c = v_float_to_half(a);//
   vec4f incMask = v_cmp_gt(v_half_to_float(c), a);
   return v_btseli(c, v_addi(c, v_splatsi(1)), v_cast_vec4i(incMask));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float(const uint16_t* __restrict m)
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float(const uint16_t* __restrict m)
 {
   return v_half_to_float(v_lduush((const unsigned short*)m));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_half_to_float_specials(const uint16_t* __restrict m)
+VECTORCALL VECMATH_FINLINE vec4f v_half_to_float_specials(const uint16_t* __restrict m)
 {
   return v_half_to_float_specials(v_lduush((const unsigned short*)m));
 }
@@ -3048,7 +3031,7 @@ VECMATH_FINLINE vec4f v_byte_to_float ( uint32_t x )
     return v_cvt_vec4f(y);
 }
 
-VECMATH_INLINE int VECTORCALL v_test_triangle_sphere_intersection(vec3f A, vec3f B, vec3f C, vec4f sph_c, vec4f sph_r2)
+VECTORCALL VECMATH_INLINE  int v_test_triangle_sphere_intersection(vec3f A, vec3f B, vec3f C, vec4f sph_c, vec4f sph_r2)
 {
   A = v_sub(A, sph_c);
   B = v_sub(B, sph_c);
@@ -3092,7 +3075,7 @@ VECMATH_INLINE int VECTORCALL v_test_triangle_sphere_intersection(vec3f A, vec3f
             v_and(v_cmp_gt(v_dot3_x(Q3, Q3), v_mul_x(sph_r2, v_mul_x(e3, e3))), v_cmp_gt(v_dot3_x(Q3, QB), v_zero()))));
 }
 
-VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& p1, const vec3f& p2, const vec3f& p3 )
+VECTORCALL VECMATH_INLINE  vec3f v_triangle_bounding_sphere_center( const vec3f& p1, const vec3f& p2, const vec3f& p3 )
 {
   vec3f edge1 = v_sub(p2, p1);
   vec3f edge2 = v_sub(p3, p1);
@@ -3132,7 +3115,7 @@ VECMATH_INLINE vec3f VECTORCALL v_triangle_bounding_sphere_center( const vec3f& 
                cmul2);//r       = 0.5f * sqrt( fabsf(safediv((nd1 + nd2) * (nd2 + nd3) * (nd3 + nd1), c)) );
 }
 
-VECMATH_INLINE bool VECTORCALL v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3)
+VECTORCALL VECMATH_INLINE  bool v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4f t2, vec4f t3)
 {
   vec3f t123y = v_perm_xyab(v_perm_xaxa(v_splat_y(t1), v_splat_y(t2)), v_splat_y(t3));
   vec3f t123x = v_perm_xyab(v_perm_xaxa(t1, t2), t3);
@@ -3148,28 +3131,28 @@ VECMATH_INLINE bool VECTORCALL v_is_point_in_triangle_2d(vec4f p, vec4f t1, vec4
 }
 
 //this is ~3 times faster for valid floats (not nans, infs, etc), than int(floorf())
-VECMATH_INLINE int VECTORCALL vec_floori(float x)
+VECTORCALL VECMATH_INLINE  int vec_floori(float x)
 {
   return v_extract_xi(v_cvt_floori(v_splats(x)));
 }
 
 //this is ~2 times faster for valid floats (not nans, infs, etc), than int(floorf())
-VECMATH_INLINE int VECTORCALL vec_float_to_int(float x)
+VECTORCALL VECMATH_INLINE  int vec_float_to_int(float x)
 {
   return v_extract_xi(v_cvt_vec4i(v_splats(x)));
 }
 
 VECMATH_INLINE float invsqrt(float x) { return v_extract_x(v_rsqrt_x(v_set_x(x))); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xzac(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xzac(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyab(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xyab(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xycd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xycd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xbzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xayb(v_perm_xzxz(v_cast_vec4f(xyzw)), v_perm_ywyw(v_cast_vec4f(abcd)))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xyzd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xzxz(vec4i xyzw) { return v_cast_vec4i(v_perm_xzxz(v_cast_vec4f(xyzw))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_ywyw(vec4i xyzw) { return v_cast_vec4i(v_perm_ywyw(v_cast_vec4f(xyzw))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_xyxy(vec4i xyzw) { return v_cast_vec4i(v_perm_xyxy(v_cast_vec4f(xyzw))); }
-VECMATH_FINLINE vec4i VECTORCALL v_permi_zwzw(vec4i xyzw) { return v_cast_vec4i(v_perm_zwzw(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzac(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xzac(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyab(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xyab(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xycd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xycd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xbzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xayb(v_perm_xzxz(v_cast_vec4f(xyzw)), v_perm_ywyw(v_cast_vec4f(abcd)))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyzd(vec4i xyzw, vec4i abcd) { return v_cast_vec4i(v_perm_xyzd(v_cast_vec4f(xyzw), v_cast_vec4f(abcd))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xzxz(vec4i xyzw) { return v_cast_vec4i(v_perm_xzxz(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_ywyw(vec4i xyzw) { return v_cast_vec4i(v_perm_ywyw(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_xyxy(vec4i xyzw) { return v_cast_vec4i(v_perm_xyxy(v_cast_vec4f(xyzw))); }
+VECTORCALL VECMATH_FINLINE vec4i v_permi_zwzw(vec4i xyzw) { return v_cast_vec4i(v_perm_zwzw(v_cast_vec4f(xyzw))); }
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/dag_vecMath_neon.h
+++ b/dag_vecMath_neon.h
@@ -7,63 +7,63 @@
 
 #define VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE 1e-16
 
-VECMATH_FINLINE vec4f VECTORCALL v_zero() { return vdupq_n_f32(0); }
-VECMATH_FINLINE vec4i VECTORCALL v_zeroi() { return vdupq_n_u32(0); }
-VECMATH_FINLINE vec4f VECTORCALL v_set_all_bits() { vec4f u = v_zero(); return v_cmp_eq(u, u); }
-VECMATH_FINLINE vec4i VECTORCALL v_set_all_bitsi() { vec4i u = v_zeroi(); return v_cmp_eqi(u, u); }
-VECMATH_FINLINE vec4f VECTORCALL v_msbit() { return (vec4f)vdupq_n_u32(0x80000000); }
-VECMATH_FINLINE vec4f VECTORCALL v_splat4(const float *a) { return vld1q_dup_f32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_ld(const float *m) { return vld1q_f32(m); }
-VECMATH_FINLINE vec4f VECTORCALL v_ldu(const float *m) { return vld1q_f32(m); }
-VECMATH_FINLINE vec4f VECTORCALL v_ldu_x(const float *m) { return vsetq_lane_f32(*m, v_zero(), 0); } // load x, zero others
-VECMATH_FINLINE vec4i VECTORCALL v_ldi(const int *m) { return vld1q_s32(m); }
-VECMATH_FINLINE vec4i VECTORCALL v_ldui(const int *m) { return vld1q_s32(m); }
-VECMATH_FINLINE vec4i VECTORCALL v_ldush(const signed short *m) { return vmovl_s16(vld1_s16(m)); }
-VECMATH_FINLINE vec4i VECTORCALL v_lduush(const unsigned short *m) { return (vec4i)vmovl_u16(vld1_u16(m)); }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_x(vec4f a) { return vdupq_lane_f32(vget_low_f32(a), 0); }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_y(vec4f a) { return vdupq_lane_f32(vget_low_f32(a), 1); }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_z(vec4f a) { return vdupq_lane_f32(vget_high_f32(a), 0); }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_w(vec4f a) { return vdupq_lane_f32(vget_high_f32(a), 1); }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_xi(vec4i a) { return vdupq_lane_s32(vget_low_s32(a), 0); }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_yi(vec4i a) { return vdupq_lane_s32(vget_low_s32(a), 1); }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_zi(vec4i a) { return vdupq_lane_s32(vget_high_s32(a), 0); }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_wi(vec4i a) { return vdupq_lane_s32(vget_high_s32(a), 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_zero() { return vdupq_n_f32(0); }
+VECTORCALL VECMATH_FINLINE vec4i v_zeroi() { return vdupq_n_u32(0); }
+VECTORCALL VECMATH_FINLINE vec4f v_set_all_bits() { vec4f u = v_zero(); return v_cmp_eq(u, u); }
+VECTORCALL VECMATH_FINLINE vec4i v_set_all_bitsi() { vec4i u = v_zeroi(); return v_cmp_eqi(u, u); }
+VECTORCALL VECMATH_FINLINE vec4f v_msbit() { return (vec4f)vdupq_n_u32(0x80000000); }
+VECTORCALL VECMATH_FINLINE vec4f v_splat4(const float *a) { return vld1q_dup_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_ld(const float *m) { return vld1q_f32(m); }
+VECTORCALL VECMATH_FINLINE vec4f v_ldu(const float *m) { return vld1q_f32(m); }
+VECTORCALL VECMATH_FINLINE vec4f v_ldu_x(const float *m) { return vsetq_lane_f32(*m, v_zero(), 0); } // load x, zero others
+VECTORCALL VECMATH_FINLINE vec4i v_ldi(const int *m) { return vld1q_s32(m); }
+VECTORCALL VECMATH_FINLINE vec4i v_ldui(const int *m) { return vld1q_s32(m); }
+VECTORCALL VECMATH_FINLINE vec4i v_ldush(const signed short *m) { return vmovl_s16(vld1_s16(m)); }
+VECTORCALL VECMATH_FINLINE vec4i v_lduush(const unsigned short *m) { return (vec4i)vmovl_u16(vld1_u16(m)); }
+VECTORCALL VECMATH_FINLINE vec4f v_splat_x(vec4f a) { return vdupq_lane_f32(vget_low_f32(a), 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_splat_y(vec4f a) { return vdupq_lane_f32(vget_low_f32(a), 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_splat_z(vec4f a) { return vdupq_lane_f32(vget_high_f32(a), 0); }
+VECTORCALL VECMATH_FINLINE vec4f v_splat_w(vec4f a) { return vdupq_lane_f32(vget_high_f32(a), 1); }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_xi(vec4i a) { return vdupq_lane_s32(vget_low_s32(a), 0); }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_yi(vec4i a) { return vdupq_lane_s32(vget_low_s32(a), 1); }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_zi(vec4i a) { return vdupq_lane_s32(vget_high_s32(a), 0); }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_wi(vec4i a) { return vdupq_lane_s32(vget_high_s32(a), 1); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_splats(float a) { return vmovq_n_f32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi(int a) {return vmovq_n_s32(a);}
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi64(int64_t a) {return vdupq_n_s64(a);}
-VECMATH_FINLINE vec4f VECTORCALL v_set_x(float a) { return vsetq_lane_f32(a, v_zero(), 0); } // set x, zero others
-VECMATH_FINLINE vec4i VECTORCALL v_seti_x(int a) { return vsetq_lane_s32(a, v_zero(), 0); } // set x, zero others
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f(float x, float y, float z, float w) { return (vec4f){x, y, z, w}; }
-VECMATH_FINLINE vec4i VECTORCALL v_make_vec4i(int x, int y, int z, int w)
+VECTORCALL VECMATH_FINLINE vec4f v_splats(float a) { return vmovq_n_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi(int a) {return vmovq_n_s32(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi64(int64_t a) {return vdupq_n_s64(a);}
+VECTORCALL VECMATH_FINLINE vec4f v_set_x(float a) { return vsetq_lane_f32(a, v_zero(), 0); } // set x, zero others
+VECTORCALL VECMATH_FINLINE vec4i v_seti_x(int a) { return vsetq_lane_s32(a, v_zero(), 0); } // set x, zero others
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec4f(float x, float y, float z, float w) { return (vec4f){x, y, z, w}; }
+VECTORCALL VECMATH_FINLINE vec4i v_make_vec4i(int x, int y, int z, int w)
 {
   alignas(16) int data[4] = { x, y, z, w };
   return vld1q_s32(data);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(float x, float y, float z) { return v_make_vec4f(x, y, z, z); }
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(vec4f x, vec4f y, vec4f z)
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(float x, float y, float z) { return v_make_vec4f(x, y, z, z); }
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z)
 {
   return __builtin_shufflevector(__builtin_shufflevector(x, y, 0, 0, 4, 4), z, 0, 2, 4, 4);
 }
 
-VECMATH_FINLINE void VECTORCALL v_st(void *m, vec4f v)  { vst1q_f32((float*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stu(void *m, vec4f v) { vst1q_f32((float*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_sti(void *m, vec4i v)  { vst1q_s32((int*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stui(void *m, vec4i v) { vst1q_s32((int*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stui_half(void *m, vec4i v) { vst1_s32((int*)m, vget_low_s32(v)); }
-VECMATH_FINLINE void VECTORCALL v_stu_half(void *m, vec4f v) { vst1_f32((float*)m, vget_low_f32(v)); }
-VECMATH_FINLINE void VECTORCALL v_stu_p3(float *p3, vec3f v) { v_stu_half(p3, v); p3[2] = v_extract_z(v); }
+VECTORCALL VECMATH_FINLINE void v_st(void *m, vec4f v)  { vst1q_f32((float*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stu(void *m, vec4f v) { vst1q_f32((float*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_sti(void *m, vec4i v)  { vst1q_s32((int*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stui(void *m, vec4i v) { vst1q_s32((int*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stui_half(void *m, vec4i v) { vst1_s32((int*)m, vget_low_s32(v)); }
+VECTORCALL VECMATH_FINLINE void v_stu_half(void *m, vec4f v) { vst1_f32((float*)m, vget_low_f32(v)); }
+VECTORCALL VECMATH_FINLINE void v_stu_p3(float *p3, vec3f v) { v_stu_half(p3, v); p3[2] = v_extract_z(v); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_merge_hw(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_merge_hw(vec4f a, vec4f b)
 {
   return vzipq_f32(a, b).val[0];
 }
-VECMATH_FINLINE vec4f VECTORCALL v_merge_lw(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b)
 {
   return vzipq_f32(a, b).val[1];
 }
 
-VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a)
+VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a)
 {
   static const vec4i movemask = { 1, 2, 4, 8 };
   vec4i t0 = v_cast_vec4i(a);
@@ -72,7 +72,7 @@ VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a)
   return vaddvq_s32(t2);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_zeros(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a)
 {
   uint64x2_t v64 = vreinterpretq_u64_f32(a);
   uint32x2_t v32 = vqmovn_u64(v64); // saturate uint32x4 to uint16x4 packed in uint64 (1 => 1; 0x12345 => 0xffff)
@@ -80,69 +80,69 @@ VECMATH_FINLINE bool VECTORCALL v_test_all_bits_zeros(vec4f a)
   return result[0] == 0u;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_ones(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_ones(vec4f a)
 {
   return v_test_any_bit_set(v_not(a));
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_any_bit_set(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_any_bit_set(vec4f a)
 {
   return !v_test_all_bits_zeros(a);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyzw_all_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyzw_all_not_zeroi(vec4f a)
 {
   return v_test_all_bits_zeros(v_cmp_eq(a, v_zero()));
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_zeroi(vec4f a)
 {
   return v_test_all_bits_zeros(v_perm_xyzz(a));
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_not_zeroi(vec4f a)
 {
   return v_check_xyzw_all_not_zeroi(v_perm_xyzz(a));
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_any_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_any_not_zeroi(vec4f a)
 {
   return v_test_any_bit_set(v_perm_xyzz(a));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b) { return (vec4f)vceqq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b) { return (vec4f)vmvnq_u32(vceqq_f32(a, b)); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b) { return (vec4f)vceqq_s32((vec4i)a, (vec4i)b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b) { return (vec4i)vceqq_s32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_ge(vec4f a, vec4f b) { return (vec4f)vcgeq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_gt(vec4f a, vec4f b) { return (vec4f)vcgtq_f32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_lti(vec4i a, vec4i b) { return (vec4i)vcltq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_gti(vec4i a, vec4i b) { return (vec4i)vcgtq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eq(vec4f a, vec4f b) { return (vec4f)vceqq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_neq(vec4f a, vec4f b) { return (vec4f)vmvnq_u32(vceqq_f32(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eqi(vec4f a, vec4f b) { return (vec4f)vceqq_s32((vec4i)a, (vec4i)b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi(vec4i a, vec4i b) { return (vec4i)vceqq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_ge(vec4f a, vec4f b) { return (vec4f)vcgeq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_gt(vec4f a, vec4f b) { return (vec4f)vcgtq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_lti(vec4i a, vec4i b) { return (vec4i)vcltq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_gti(vec4i a, vec4i b) { return (vec4i)vcgtq_s32(a, b); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_and(vec4f a, vec4f b) { return (vec4f)vandq_s32((vec4i)a, (vec4i)b); }
-VECMATH_FINLINE vec4f VECTORCALL v_andnot(vec4f a, vec4f b) { return (vec4f)vandq_s32(vmvnq_s32((vec4i)a), (vec4i)b); }
-VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b) { return (vec4f)vorrq_s32((vec4i)a, (vec4i)b); }
-VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b) { return (vec4f)veorq_s32((vec4i)a, (vec4i)b); }
-VECMATH_FINLINE vec4f VECTORCALL v_not(vec4f a) { return (vec4f)vmvnq_u32((vec4i)a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_and(vec4f a, vec4f b) { return (vec4f)vandq_s32((vec4i)a, (vec4i)b); }
+VECTORCALL VECMATH_FINLINE vec4f v_andnot(vec4f a, vec4f b) { return (vec4f)vandq_s32(vmvnq_s32((vec4i)a), (vec4i)b); }
+VECTORCALL VECMATH_FINLINE vec4f v_or(vec4f a, vec4f b) { return (vec4f)vorrq_s32((vec4i)a, (vec4i)b); }
+VECTORCALL VECMATH_FINLINE vec4f v_xor(vec4f a, vec4f b) { return (vec4f)veorq_s32((vec4i)a, (vec4i)b); }
+VECTORCALL VECMATH_FINLINE vec4f v_not(vec4f a) { return (vec4f)vmvnq_u32((vec4i)a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c)
 {
   return vbslq_f32((uint32x4_t)vshrq_n_s32(vreinterpretq_s32_f32(c), 31), b, a);
 }
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)vshrq_n_s32(c, 31), b, a); }
-VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c) { return vbslq_f32((uint32x4_t)c, b, a); }
-VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)c, b, a); }
+VECTORCALL VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)vshrq_n_s32(c, 31), b, a); }
+VECTORCALL VECMATH_FINLINE vec4f v_btsel(vec4f a, vec4f b, vec4f c) { return vbslq_f32((uint32x4_t)c, b, a); }
+VECTORCALL VECMATH_FINLINE vec4i v_btseli(vec4i a, vec4i b, vec4i c) { return vbslq_s32((uint32x4_t)c, b, a); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvti_vec4i(vec4f a) { return vcvtq_s32_f32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i_ieee(vec4f a) { return vcvtq_u32_f32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i(vec4f a) { return v_cvtu_vec4i_ieee(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f_ieee(vec4i a) { return vcvtq_f32_u32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f(vec4i a) { return v_cvtu_vec4f_ieee(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cvti_vec4f(vec4i a) { return vcvtq_f32_s32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvti_vec4i(vec4f a) { return vcvtq_s32_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a) { return vcvtq_u32_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a) { return v_cvtu_vec4i_ieee(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f_ieee(vec4i a) { return vcvtq_f32_u32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f(vec4i a) { return v_cvtu_vec4f_ieee(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a) { return vcvtq_f32_s32(a); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cast_vec4i(vec4f a) { return vreinterpretq_s32_f32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cast_vec4f(vec4i a) { return vreinterpretq_f32_s32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cast_vec4i(vec4f a) { return vreinterpretq_s32_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a) { return vreinterpretq_f32_s32(a); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a)
 {
   vec4i xi, xi1;
   vec4f inrange;
@@ -160,7 +160,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a)
   // If truncated value is greater than input, subtract one.
   return v_sel(truncated, truncated1, v_cmp_gt(truncated, a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a)
 {
   vec4i xi, xi1;
   vec4f inrange;
@@ -178,273 +178,273 @@ VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a)
   // If truncated value is greater than input, subtract one.
   return v_sel(truncated, truncated1, v_cmp_gt(a, truncated));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_floori(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_floori(vec4f a)
 {
   vec4i xi = v_cvt_vec4i(a);
   vec4i xi1 = vsubq_s32(xi, vdupq_n_s32(1));
   return (vec4i)v_sel((vec4f)xi, (vec4f)xi1, v_cmp_gt(v_cvt_vec4f(xi), a));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL sse4_floor(vec4f a) { return v_floor(a); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_ceil(vec4f a) { return v_ceil(a); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_round(vec4f a) { return v_round(a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_floori(vec4f a) { return v_cvt_floori(a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_ceili(vec4f a)  { return v_cvt_ceili(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_floor(vec4f a) { return v_floor(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_ceil(vec4f a) { return v_ceil(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_round(vec4f a) { return v_round(a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_floori(vec4f a) { return v_cvt_floori(a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_ceili(vec4f a)  { return v_cvt_ceili(a); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a)
 {
   vec4i xi = v_cvt_vec4i(a);
   vec4i xi1 = vaddq_s32(xi, vdupq_n_s32(1));
   return (vec4i)v_sel((vec4f)xi, (vec4f)xi1, v_cmp_gt(a, v_cvt_vec4f(xi)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a) { return v_floor(v_add(a, V_C_HALF)); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_roundi(vec4f a) { return v_cvt_floori(v_add(a, V_C_HALF)); }
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a) { return v_floor(v_add(a, V_C_HALF)); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a) { return v_cvt_floori(v_add(a, V_C_HALF)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_add(vec4f a, vec4f b) { return vaddq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sub(vec4f a, vec4f b) { return vsubq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_mul(vec4f a, vec4f b) { return vmulq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
-VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b) { return vaddq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b) { return vsubq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b) { return vmulq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
-VECMATH_FINLINE vec4f VECTORCALL v_nmsub_x(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b) { return vaddq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b) { return vsubq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b) { return vmulq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { return vaddq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { return vsubq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { return vmulq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return vmlaq_f32(c, a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { return vsubq_f32(vmulq_f32(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c) { return vmlsq_f32(c, a, b); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_addi(vec4i a, vec4i b) { return vaddq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_subi(vec4i a, vec4i b) { return vsubq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_muli(vec4i a, vec4i b) { return vmulq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_addi(vec4i a, vec4i b) { return vaddq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_subi(vec4i a, vec4i b) { return vsubq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b) { return vmulq_s32(a, b); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_hadd4_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 {
   return v_set_x(vaddvq_s32(a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hadd3_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec4f a)
 {
   vec4f s = v_add_x(a, v_splat_y(a));
   return v_add_x(s, v_splat_z(a));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est(vec4f a) { return vrecpeq_f32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_iter(vec4f a, vec4f est)
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est(vec4f a) { return vrecpeq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_iter(vec4f a, vec4f est)
 {
   return vmulq_f32(est, vrecpsq_f32(est, a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_rcp(vec4f a)
 {
   return v_rcp_iter(a, v_rcp_iter(a, vrecpeq_f32(a)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est_x(vec4f a) { return vrecpeq_f32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_x(vec4f a) { return v_rcp(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_div(vec4f a, vec4f b) { return v_mul(a, v_rcp(b)); }
-VECMATH_FINLINE vec4f VECTORCALL v_div_x(vec4f a, vec4f b) { return v_mul(a, v_rcp(b)); }
-VECMATH_FINLINE vec4f VECTORCALL v_min(vec4f a, vec4f b) { return vminq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_max(vec4f a, vec4f b) { return vmaxq_f32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_neg(vec4f a) { return vnegq_f32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_negi(vec4i a){ return vnegq_s32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_abs(vec4f a) { return vabsq_f32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_absi(vec4i a) { return vabsq_s32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_maxi(vec4i a, vec4i b) { return vmaxq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_mini(vec4i a, vec4i b) { return vminq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_maxu(vec4i a, vec4i b) { return vmaxq_u32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_minu(vec4i a, vec4i b) { return vminq_u32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a) { return vrecpeq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_x(vec4f a) { return v_rcp(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b) { return v_mul(a, v_rcp(b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b) { return v_mul(a, v_rcp(b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b) { return vminq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b) { return vmaxq_f32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_neg(vec4f a) { return vnegq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a){ return vnegq_s32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a) { return vabsq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a) { return vabsq_s32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b) { return vmaxq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b) { return vminq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b) { return vmaxq_u32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b) { return vminq_u32(a, b); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4_fast(vec4f a) { return vrsqrteq_f32(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4_fast(vec4f a) { return vrsqrteq_f32(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4(vec4f a)
 {
   vec4f e = vrsqrteq_f32(a);
   e = vmulq_f32(e , vrsqrtsq_f32(vmulq_f32(e, e), a));
   return vmulq_f32(e , vrsqrtsq_f32(vmulq_f32(e, e), a));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_fast_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_fast_x(vec4f a)
 {
   float32x2_t e = vrsqrte_f32(vget_low_f32(a));
   return vcombine_f32(e, e);
 }
-VECMATH_FINLINE float32x2_t VECTORCALL v_rsqrt_x(float32x2_t a)
+VECTORCALL VECMATH_FINLINE float32x2_t v_rsqrt_x(float32x2_t a)
 {
   float32x2_t e = vrsqrte_f32(a);
   e = vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
   return vmul_f32(e, vrsqrts_f32(vmul_f32(e, e), a));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_x(vec4f a) { float32x2_t r = v_rsqrt_x(vget_low_f32(a)); return vcombine_f32(r, r); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) { float32x2_t r = v_rsqrt_x(vget_low_f32(a)); return vcombine_f32(r, r); }
 
 //sqrt of very small number (~1e-22) returns INF instead of zero, so use bigger threshold (VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE) then 0
 //added for compatibility with SSE implementation
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4_fast(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a)
 {
   return v_and(v_mul(a, vrsqrteq_f32(a)), v_cmp_gt(a, vdupq_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4(vec4f a)
 {
   return v_and(v_mul(a, v_rsqrt4(a)), v_cmp_gt(a, vdupq_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_fast_x(vec4f _a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f _a)
 {
   float32x2_t a = vget_low_f32(_a);
   float32x2_t r = (float32x2_t)vand_s32((int32x2_t)vmul_f32(a, vrsqrte_f32(a)),
     vcgt_f32(a, vdup_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
   return vcombine_f32(r, r);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_x(vec4f _a)
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f _a)
 {
   float32x2_t a = vget_low_f32(_a);
   float32x2_t r = (float32x2_t)vand_s32(vmul_f32(a, v_rsqrt_x(a)), vcgt_f32(a, vdup_n_f32(VECMATH_NEON_SQRT_MIN_THRESHOLD_VALUE)));
   return vcombine_f32(r, r);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rot_1(vec4f a) { return vextq_f32(a, a, 1); }
-VECMATH_FINLINE vec4f VECTORCALL v_rot_2(vec4f a) { return vextq_f32(a, a, 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_rot_3(vec4f a) { return vextq_f32(a, a, 3); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_1(vec4i a) { return vextq_u32(a, a, 1); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_2(vec4i a) { return vextq_u32(a, a, 2); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_3(vec4i a) { return vextq_u32(a, a, 3); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_1(vec4f a) { return vextq_f32(a, a, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_2(vec4f a) { return vextq_f32(a, a, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_3(vec4f a) { return vextq_f32(a, a, 3); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a) { return vextq_u32(a, a, 1); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a) { return vextq_u32(a, a, 2); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a) { return vextq_u32(a, a, 3); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxwz(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxwz(vec4f a)
 {
   return __builtin_shufflevector(a, a, 1, 0, 3, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxy(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a)
 {
   return __builtin_shufflevector(a, a, 1, 2, 0, 1);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxx(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a)
 {
   return __builtin_shufflevector(a, a, 1, 2, 0, 0);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxw(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a)
 {
   return __builtin_shufflevector(a, a, 1, 2, 0, 3);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxyz(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyz(vec4f a)
 {
   return __builtin_shufflevector(a, a, 2, 0, 1, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxyw(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a)
 {
   return vuzpq_f32(vextq_f32(a, a, 1), a).val[1];
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxzz(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f a)
 {
   return __builtin_shufflevector(a, a, 0, 0, 2, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yyww(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f a)
 {
   return __builtin_shufflevector(a, a, 1, 1, 3, 3);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyxy(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f a)
 {
   return __builtin_shufflevector(a, a, 0, 1, 0, 1);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwzw(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f a)
 {
   return __builtin_shufflevector(a, a, 2, 3, 2, 3);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xaxa(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xaxa(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t XY = vget_low_f32(abcd);
   float32x2x2_t xX_yY = vtrn_f32(xy, XY);
   return vcombine_f32(xX_yY.val[0], xX_yY.val[0]);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yybb(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd)
 {
   float32x2_t yy = vdup_lane_f32(vget_low_f32(xyzw), 1);
   float32x2_t bb = vdup_lane_f32(vget_low_f32(abcd), 1);
   return vcombine_f32(yy, bb);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyab(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 1, 4, 5);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd)
 {
   return vcombine_f32(vget_low_f32(xyzw), vget_high_f32(abcd));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxaa(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxaa(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 0, 4, 4);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wwdd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wwdd(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 3, 3, 7, 7);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxba(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxba(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 1, 0, 5, 4);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_wzdc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_wzdc(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 3, 2, 7, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwcd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd)
 {
   return vcombine_f32(vget_high_f32(xyzw), vget_high_f32(abcd));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwba(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwba(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 2, 3, 5, 4);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zbwa(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zbwa(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 2, 5, 3, 4);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzac(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 2, 4, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywbd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 1, 3, 5, 7);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2x2_t cx_dy = vzip_f32(vget_high_f32(abcd), xy);
   float32x2_t cx = cx_dy.val[0];
   return vcombine_f32(xy, cx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ycxy(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ycxy(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t cd = vget_high_f32(abcd);
   float32x2_t yc = vext_f32(xy, cd, 1);
   return vcombine_f32(yc, xy);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_cxyc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_cxyc(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 6, 0, 1, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycc(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzz(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzz(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 5, 2, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbcc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbcc(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 5, 6, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzw(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 5, 2, 3);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zayx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd)
 {
   float32x2x2_t za_wb = vtrn_f32(vget_high_f32(xyzw), vget_low_f32(abcd));
   float32x2_t za = za_wb.val[0];
   float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
   return vcombine_f32(za, yx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxxb(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t zw = vget_high_f32(xyzw);
@@ -453,31 +453,31 @@ VECMATH_FINLINE vec4f VECTORCALL v_perm_zxxb(vec4f xyzw, vec4f abcd)
   float32x2x2_t xb_ya = vzip_f32(xy, ba);
   return vcombine_f32(zx_wy.val[0], xb_ya.val[0]);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxxc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t cd = vget_high_f32(abcd);
   return vcombine_f32(vrev64_f32(xy), vzip_f32(xy, cd).val[0]);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxac(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxac(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 1, 0, 4, 6);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 1, 2, 7);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycw(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 0, 1, 6, 3);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bzxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t bz = vext_f32(vget_low_f32(abcd), vget_high_f32(xyzw), 1);
   float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
   return vcombine_f32(bz, xx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzya(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t yx = vrev64_f32(xy);
@@ -485,225 +485,225 @@ VECMATH_FINLINE vec4f VECTORCALL v_perm_xzya(vec4f xyzw, vec4f abcd)
   float32x2x2_t ya_xb = vzip_f32(yx, vget_low_f32(abcd));
   return vcombine_f32(xz_yw.val[0], ya_xb.val[0]);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ayzw(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd)
 {
   return __builtin_shufflevector(xyzw, abcd, 4, 1, 2, 3);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_caxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t dc = vrev64_f32(vget_high_f32(abcd));
   float32x2_t xx = vdup_lane_f32(vget_low_f32(xyzw), 0);
   float32x2_t ca = vext_f32(dc, vget_low_f32(abcd), 1);
   return vcombine_f32(ca, xx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yaxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t ya = vext_f32(xy, vget_low_f32(abcd), 1);
   float32x2_t xx = vdup_lane_f32(xy, 0);
   return vcombine_f32(ya, xx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bbyx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t bb = vdup_lane_f32(vget_low_f32(abcd), 1);
   float32x2_t yx = vrev64_f32(vget_low_f32(xyzw));
   return vcombine_f32(bb, yx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzbx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
 {
   float32x2_t xy = vget_low_f32(xyzw);
   float32x2_t xz = vzip_f32(xy, vget_high_f32(xyzw)).val[0];
   float32x2_t bx = vext_f32(vget_low_f32(abcd), xy, 1);
   return vcombine_f32(xz, bx);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzxz(vec4f xyzw)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f xyzw)
 {
   return __builtin_shufflevector(xyzw, xyzw, 0, 2, 0, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywyw(vec4f xyzw)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f xyzw)
 {
   return __builtin_shufflevector(xyzw, xyzw, 1, 3, 1, 3);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzz(vec4f xyzw)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f xyzw)
 {
   return __builtin_shufflevector(xyzw, xyzw, 0, 1, 2, 2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxyy(vec4f xyzw)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f xyzw)
 {
   return __builtin_shufflevector(xyzw, xyzw, 0, 0, 1, 1);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zzww(vec4f xyzw)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f xyzw)
 {
   return __builtin_shufflevector(xyzw, xyzw, 2, 2, 3, 3);
 }
 
 
-VECMATH_FINLINE vec4f VECTORCALL v_transpose3x(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose3x(vec4f a, vec4f b, vec4f c)
 {
   float32x2_t a0b0 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[0];
   float32x2_t c0c0 = vdup_lane_f32(vget_low_f32(c), 0);
   return vcombine_f32(a0b0, c0c0);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose3y(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose3y(vec4f a, vec4f b, vec4f c)
 {
   float32x2_t a1b1 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[1];
   float32x2_t c1c1 = vdup_lane_f32(vget_low_f32(c), 1);
   return vcombine_f32(a1b1, c1c1);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose3z(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose3z(vec4f a, vec4f b, vec4f c)
 {
   float32x2_t a2b2 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[0];
   float32x2_t c2c2 = vdup_lane_f32(vget_high_f32(c), 0);
   return vcombine_f32(a2b2, c2c2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose3w(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose3w(vec4f a, vec4f b, vec4f c)
 {
   float32x2_t a3b3 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[1];
   float32x2_t c3c3 = vdup_lane_f32(vget_high_f32(c), 1);
   return vcombine_f32(a3b3, c3c3);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_transpose4x(vec4f a, vec4f b, vec4f c, vec4f d)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose4x(vec4f a, vec4f b, vec4f c, vec4f d)
 {
   float32x2_t a0b0 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[0];
   float32x2_t c0d0 = vtrn_f32(vget_low_f32(c), vget_low_f32(d)).val[0];
   return vcombine_f32(a0b0, c0d0);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose4y(vec4f a, vec4f b, vec4f c, vec4f d)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose4y(vec4f a, vec4f b, vec4f c, vec4f d)
 {
   float32x2_t a1b1 = vtrn_f32(vget_low_f32(a), vget_low_f32(b)).val[1];
   float32x2_t c1d1 = vtrn_f32(vget_low_f32(c), vget_low_f32(d)).val[1];
   return vcombine_f32(a1b1, c1d1);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose4z(vec4f a, vec4f b, vec4f c, vec4f d)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose4z(vec4f a, vec4f b, vec4f c, vec4f d)
 {
   float32x2_t a2b2 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[0];
   float32x2_t c2d2 = vtrn_f32(vget_high_f32(c), vget_high_f32(d)).val[0];
   return vcombine_f32(a2b2, c2d2);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_transpose4w(vec4f a, vec4f b, vec4f c, vec4f d)
+VECTORCALL VECMATH_FINLINE vec4f v_transpose4w(vec4f a, vec4f b, vec4f c, vec4f d)
 {
   float32x2_t a3b3 = vtrn_f32(vget_high_f32(a), vget_high_f32(b)).val[1];
   float32x2_t c3d3 = vtrn_f32(vget_high_f32(c), vget_high_f32(d)).val[1];
   return vcombine_f32(a3b3, c3d3);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_dot2(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b)
 {
   float32x2_t m = vmul_f32(vget_low_f32(a), vget_low_f32(b));
   return vdupq_lane_f32(vadd_f32(m, vrev64_f32(m)), 0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_dot2_x(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b)
 {
   float32x2_t m = vmul_f32(vget_low_f32(a), vget_low_f32(b));
   return vdupq_lane_f32(vadd_f32(m, vrev64_f32(m)), 0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_dot3_x(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b)
 {
   vec4f m;
   m = v_mul(a, b);
   m = v_madd(v_rot_1(a), v_rot_1(b), m);
   return v_madd(v_rot_2(a), v_rot_2(b), m);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3(vec4f a, vec4f b) { return v_splat_x(v_dot3_x(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return v_splat_x(v_dot3_x(a, b)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_dot4(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b)
 {
   vec4f m;
   m = v_mul(a, b);
   m = v_madd(v_rot_1(a), v_rot_1(b), m);
   return v_add(v_rot_2(m), m);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_dot4_x(vec4f a, vec4f b) { return v_dot4(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return v_dot4(a,b); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq(vec4f a)
 {
   vec4f m = v_mul(a, a);
   vec4f ar1 = v_rot_1(a);
   m = v_madd(ar1, ar1, m);
   return v_add(v_rot_2(m), m);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_length4_sq_x(vec4f a) { return v_length4_sq(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_length4_sq_x(vec4f a) { return v_length4_sq(a); }
 
-VECMATH_FINLINE float32x2_t VECTORCALL v_length4_sq_xd(vec4f a)
+VECTORCALL VECMATH_FINLINE float32x2_t v_length4_sq_xd(vec4f a)
 {
   vec4f m = v_mul(a, a);
   float32x2_t m2 = vadd_f32(vget_low_f32(m), vget_high_f32(m));
   return vadd_f32(m2, vext_f32(m2, m2, 1));
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq(vec3f a)
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq(vec3f a)
 {
   vec4f m = v_mul(a, a);
   vec4f ar1 = v_rot_1(a), ar2 = v_rot_2(m);
   m = v_madd(ar1, ar1, m);
   return v_splat_x(v_add(ar2, m));
 }
-VECMATH_FINLINE vec3f VECTORCALL v_length3_sq_x(vec3f a)
+VECTORCALL VECMATH_FINLINE vec3f v_length3_sq_x(vec3f a)
 {
   return v_length3_sq(a);
 }
-VECMATH_FINLINE float32x2_t VECTORCALL v_length3_sq_xd(vec3f a)
+VECTORCALL VECMATH_FINLINE float32x2_t v_length3_sq_xd(vec3f a)
 {
   vec4f m = v_mul(a, a);
   float32x2_t ar1 = vget_low_f32(v_rot_1(a)), ar2 = vget_high_f32(m);
   float32x2_t m2 = vmla_f32(vget_low_f32(m), ar1, ar1);
   return vadd_f32(ar2, m2);
 }
-VECMATH_FINLINE float32x2_t VECTORCALL v_length2_sq_xd(vec4f a)
+VECTORCALL VECMATH_FINLINE float32x2_t v_length2_sq_xd(vec4f a)
 {
   float32x2_t xy = vget_low_f32(a);
   float32x2_t m = vmul_f32(xy, xy);
   return vadd_f32(m, vrev64_f32(m));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq(vec4f a)
 {
    return vdupq_lane_f32(v_length2_sq_xd(a), 0);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_length2_sq_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_length2_sq_x(vec4f a)
 {
    return vdupq_lane_f32(v_length2_sq_xd(a), 0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_norm4(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length4_sq_xd(a)), 0)); }
-VECMATH_FINLINE vec4f VECTORCALL v_norm3(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length3_sq_xd(a)), 0)); }
-VECMATH_FINLINE vec4f VECTORCALL v_norm2(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length2_sq_xd(a)), 0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length4_sq_xd(a)), 0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length3_sq_xd(a)), 0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_mul(a, vdupq_lane_f32(v_rsqrt_x(v_length2_sq_xd(a)), 0)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist_x(plane3f a, vec3f b) { return v_add_x(v_dot3_x(a,b), v_rot_3(a)); }
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist(plane3f a, vec3f b) { return v_splat_x(v_plane_dist_x(a,b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return v_add_x(v_dot3_x(a,b), v_rot_3(a)); }
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b) { return v_splat_x(v_plane_dist_x(a,b)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxz(vec4f a) { return __builtin_shufflevector(a, a, 1, 2, 0, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxz(vec4f a) { return __builtin_shufflevector(a, a, 1, 2, 0, 2); }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_ident(mat44f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat44_ident(mat44f &dest)
 {
   dest.col3 = V_C_UNIT_0001;
   dest.col2 = v_rot_1(dest.col3);
   dest.col1 = v_rot_1(dest.col2);
   dest.col0 = v_rot_1(dest.col1);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_ident_swapxz(mat44f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat44_ident_swapxz(mat44f &dest)
 {
   dest.col3 = V_C_UNIT_0001;
   dest.col0 = v_rot_1(dest.col3);
   dest.col1 = v_rot_1(dest.col0);
   dest.col2 = v_rot_1(dest.col1);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_ident(mat33f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat33_ident(mat33f &dest)
 {
   dest.col2 = V_C_UNIT_0010;
   dest.col1 = v_rot_1(dest.col2);
   dest.col0 = v_rot_1(dest.col1);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_ident_swapxz(mat33f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
 {
   dest.col0 = V_C_UNIT_0010;
   dest.col1 = v_rot_1(dest.col0);
   dest.col2 = v_rot_1(dest.col1);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(r0, r2);
@@ -716,7 +716,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r
   r3 = v_merge_lw(tmp2, tmp3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(mat44f &dest, mat44f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(src.col0, src.col2);
@@ -729,7 +729,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose(mat44f &dest, mat44f_cref src)
   dest.col3 = v_merge_lw(tmp2, tmp3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(src.row0, src.row2);
@@ -741,7 +741,7 @@ VECMATH_FINLINE void VECTORCALL v_mat43_transpose_to_mat44(mat44f &dest, mat43f_
   dest.col2 = v_merge_hw(tmp2, tmp3);
   dest.col3 = v_merge_lw(tmp2, tmp3);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   tmp0 = v_merge_hw(src.col0, src.col2);
@@ -753,7 +753,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat43(mat43f &dest, mat44f_
   dest.row2 = v_merge_hw(tmp2, tmp3);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec4(mat44f_cref m, vec4f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = v_splat_y(v);
@@ -768,7 +768,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec4(mat44f_cref m, vec4f v)
   return v_add(tmp0, tmp1);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3v(mat44f_cref m, vec4f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec4f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = v_splat_y(v);
@@ -780,7 +780,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3v(mat44f_cref m, vec4f v)
   return v_madd(m.col2, zzzz, res);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3p(mat44f_cref m, vec4f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec4f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = v_splat_y(v);
@@ -794,7 +794,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3p(mat44f_cref m, vec4f v)
   return v_add(tmp0, tmp1);
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_mat33_mul_vec3(mat33f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = v_splat_y(v);
@@ -806,7 +806,7 @@ VECMATH_FINLINE vec3f VECTORCALL v_mat33_mul_vec3(mat33f_cref m, vec3f v)
   return v_madd(m.col2, zzzz, res);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
 {
   vec4f in0 = m.col0; // AEIM
   vec4f in1 = m.col1; // BFJN
@@ -896,7 +896,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
   vec4f detA2 = v_splat_z(det1);
   vec4f detB0 = v_sub(detA0, detA1);
   vec4f det = v_sub(detB0, detA2);
-  vec4f invdet = v_rcp(det);
+  vec4f invdet = v_rcp_safe(det);
   /* Multiply the cofactors by the reciprocal of the determinant.
   */
   dest.col0 = v_mul(out1, invdet);
@@ -904,14 +904,14 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
   dest.col2 = v_mul(out3, invdet);
   dest.col3 = v_mul(out4, invdet);
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
 {
   vec4f tmp0, tmp1, tmp2, dot, invdet, inv0, inv1, inv2;
     tmp2 = v_cross3(m.col0, m.col1);
   tmp0 = v_cross3(m.col1, m.col2);
   tmp1 = v_cross3(m.col2, m.col0);
   dot = v_dot3(tmp2, m.col2);
-  invdet = v_rcp(dot);
+  invdet = v_rcp_safe(dot);
   inv0 = v_transpose3x(tmp0, tmp1, tmp2);
   inv1 = v_transpose3y(tmp0, tmp1, tmp2);
   inv2 = v_transpose3z(tmp0, tmp1, tmp2);
@@ -919,7 +919,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m)
   dest.col1 = v_mul(inv1, invdet);
   dest.col2 = v_mul(inv2, invdet);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_det(mat44f_cref m)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
 {
   vec4f tmp0, tmp1, tmp2, tmp3;
   vec4f cof0;
@@ -958,7 +958,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_det(mat44f_cref m)
   return v_dot4(t0, cof0);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_insert(float s, vec4f v, int i)
+VECTORCALL VECMATH_FINLINE vec4f v_insert(float s, vec4f v, int i)
 {
   if (i == 0)
     return v_sel(v, v_splats(s), (vec4f)V_CI_MASK0001);
@@ -971,87 +971,52 @@ VECMATH_FINLINE vec4f VECTORCALL v_insert(float s, vec4f v, int i)
   return v;
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_promote(float s, int /*i*/)
+VECTORCALL VECMATH_FINLINE vec4f v_promote(float s, int /*i*/)
 {
   return vmovq_n_f32(s);
 }
 
-VECMATH_FINLINE quat4f VECTORCALL v_un_quat_from_mat(vec3f col0, vec3f col1, vec3f col2)
-{
-  /* compute quaternion for each case */
-  const vec4f xx_yy = v_perm_xbzw(col0, col1);
-  const vec4f xx_yy_zz_xx = v_perm_xycx(xx_yy, col2);
-  const vec4f yy_zz_xx_yy = v_perm_ycxy(xx_yy, col2);
-  const vec4f zz_xx_yy_zz = v_perm_cxyc(xx_yy, col2);
+VECTORCALL VECMATH_FINLINE short v_extract_xi16(vec4i v) { return vgetq_lane_s16(vreinterpretq_s16_s32(v), 0); }
 
-  const vec4f diagSum = v_add(v_add(xx_yy_zz_xx, yy_zz_xx_yy), zz_xx_yy_zz);
-  const vec4f diagDiff = v_sub(v_sub(xx_yy_zz_xx, yy_zz_xx_yy), zz_xx_yy_zz);
-  const vec4f radicand = v_add(v_perm_xyzd(diagDiff, diagSum), V_C_ONE);
-  const vec4f invSqrt = v_rsqrt4(v_sel(radicand, V_C_ONE, v_cmp_ge(v_zero(), radicand)));
+VECTORCALL VECMATH_FINLINE float v_extract_x(vec4f v) { return vgetq_lane_f32(v, 0); }
+VECTORCALL VECMATH_FINLINE float v_extract_y(vec4f v) { return vgetq_lane_f32(v, 1); }
+VECTORCALL VECMATH_FINLINE float v_extract_z(vec4f v) { return vgetq_lane_f32(v, 2); }
+VECTORCALL VECMATH_FINLINE float v_extract_w(vec4f v) { return vgetq_lane_f32(v, 3); }
 
-  const vec4f zy_xz_yx = v_perm_zayx(v_perm_xycw(col0, col1), col2);
-  const vec4f yz_zx_xy = v_perm_bzxx(v_perm_ayzw(col0, col1), col2);
+VECTORCALL VECMATH_FINLINE int v_extract_xi(vec4i v) {return vgetq_lane_s32(v, 0);}
+VECTORCALL VECMATH_FINLINE int v_extract_yi(vec4i v) {return vgetq_lane_s32(v, 1);}
+VECTORCALL VECMATH_FINLINE int v_extract_zi(vec4i v) {return vgetq_lane_s32(v, 2);}
+VECTORCALL VECMATH_FINLINE int v_extract_wi(vec4i v) {return vgetq_lane_s32(v, 3);}
 
-  const vec4f sum = v_add(zy_xz_yx, yz_zx_xy);
-  const vec4f diff = v_sub(zy_xz_yx, yz_zx_xy);
-
-  const vec4f scale = v_mul(invSqrt, V_C_HALF);
-  const vec4f res0 = v_mul(v_perm_ayzw(v_perm_xzya(sum, diff), radicand), v_splat_x(scale));
-  const vec4f res1 = v_mul(v_perm_xbzw(v_perm_zxxb(sum, diff), radicand), v_splat_y(scale));
-  const vec4f res2 = v_mul(v_perm_xycw(v_perm_yxac(sum, diff), radicand), v_splat_z(scale));
-  const vec4f res3 = v_mul(v_perm_xyzd(diff, radicand), v_splat_w(scale));
-
-  /* determine case and select answer */
-  vec4f xx = v_splat_x(col0);
-  vec4f yy = v_splat_y(col1);
-  vec4f zz = v_splat_z(col2);
-
-  vec4f q = v_sel(res0, res1, v_cmp_gt(yy, xx));
-  q = v_sel(q, res2, v_and(v_cmp_gt(zz, xx), v_cmp_gt(zz, yy)));
-  return v_sel(q, res3, v_cmp_gt(v_splat_x(diagSum), v_zero()));
-}
-
-VECMATH_FINLINE short VECTORCALL v_extract_xi16(vec4i v) { return vgetq_lane_s16(vreinterpretq_s16_s32(v), 0); }
-
-VECMATH_FINLINE float VECTORCALL v_extract_x(vec4f v) { return vgetq_lane_f32(v, 0); }
-VECMATH_FINLINE float VECTORCALL v_extract_y(vec4f v) { return vgetq_lane_f32(v, 1); }
-VECMATH_FINLINE float VECTORCALL v_extract_z(vec4f v) { return vgetq_lane_f32(v, 2); }
-VECMATH_FINLINE float VECTORCALL v_extract_w(vec4f v) { return vgetq_lane_f32(v, 3); }
-
-VECMATH_FINLINE int VECTORCALL v_extract_xi(vec4i v) {return vgetq_lane_s32(v, 0);}
-VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v) {return vgetq_lane_s32(v, 1);}
-VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v) {return vgetq_lane_s32(v, 2);}
-VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v) {return vgetq_lane_s32(v, 3);}
-
-VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i v) {return vgetq_lane_s64(vreinterpretq_s64_s32(v), 0);}
-VECMATH_FINLINE int64_t VECTORCALL v_extract_yi64(vec4i v) { return vgetq_lane_s64(vreinterpretq_s64_s32(v), 1); }
+VECTORCALL VECMATH_FINLINE int64_t v_extract_xi64(vec4i v) {return vgetq_lane_s64(vreinterpretq_s64_s32(v), 0);}
+VECTORCALL VECMATH_FINLINE int64_t v_extract_yi64(vec4i v) { return vgetq_lane_s64(vreinterpretq_s64_s32(v), 1); }
 
 #define V_TEST_VEC_X_BIT0(v) (vget_lane_u32(v, 0) & 1)
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a)
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi(vec3f v, vec3f a)
 {
   return V_TEST_VEC_X_BIT0(vceq_s32(vget_low_f32(v), vget_low_f32(a)));
 }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcle_f32(vget_low_f32(v), vget_low_f32(a))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq_0(vec3f v) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vmov_n_f32(0))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vmov_n_f32(0))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vmov_n_f32(0))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vmov_n_f32(0))); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcle_f32(vget_low_f32(v), vmov_n_f32(0))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vget_low_f32(a))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vget_low_f32(a))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vget_low_f32(a))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vget_low_f32(a))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le(vec3f v, vec3f a) { return V_TEST_VEC_X_BIT0(vcle_f32(vget_low_f32(v), vget_low_f32(a))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq_0(vec3f v) { return V_TEST_VEC_X_BIT0(vceq_f32(vget_low_f32(v), vmov_n_f32(0))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcgt_f32(vget_low_f32(v), vmov_n_f32(0))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcge_f32(vget_low_f32(v), vmov_n_f32(0))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt_0(vec3f v) { return V_TEST_VEC_X_BIT0(vclt_f32(vget_low_f32(v), vmov_n_f32(0))); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le_0(vec3f v) { return V_TEST_VEC_X_BIT0(vcle_f32(vget_low_f32(v), vmov_n_f32(0))); }
 
 #undef V_TEST_VEC_X_BIT0
 
-VECMATH_FINLINE vec4i VECTORCALL v_ldui_half(const void *m)
+VECTORCALL VECMATH_FINLINE vec4i v_ldui_half(const void *m)
 {
   return vcombine_s32(vld1_s32((int32_t const*)m), vcreate_s32(0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_ldu_half(const void *m)
+VECTORCALL VECMATH_FINLINE vec4f v_ldu_half(const void *m)
 {
   return vreinterpretq_f32_s32(v_ldui_half(m));
 }
@@ -1060,11 +1025,11 @@ VECMATH_FINLINE void v_prefetch(const void *m)
   __builtin_prefetch(m);
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_lo_ush_vec4i(vec4i a) { return vreinterpretq_s64_s16(vzip1q_s16(vreinterpretq_s16_s64(a), vdupq_n_s16(0))); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_hi_ush_vec4i(vec4i a) { return vreinterpretq_s64_s16(vzip2q_f32(vreinterpretq_s16_s64(a), vdupq_n_s16(0))); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_lo_ush_vec4i(vec4i a) { return vreinterpretq_s64_s16(vzip1q_s16(vreinterpretq_s16_s64(a), vdupq_n_s16(0))); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_hi_ush_vec4i(vec4i a) { return vreinterpretq_s64_s16(vzip2q_f32(vreinterpretq_s16_s64(a), vdupq_n_s16(0))); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_lo_ssh_vec4i(vec4i a) { return vmovl_s16(vget_low_s16(vreinterpretq_s16_s32(a))); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_hi_ssh_vec4i(vec4i a) 
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_lo_ssh_vec4i(vec4i a) { return vmovl_s16(vget_low_s16(vreinterpretq_s16_s32(a))); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_hi_ssh_vec4i(vec4i a)
 {
   return vreinterpretq_s64_s16(vzip2q_f32(vreinterpretq_s16_s64(a), vcltq_s16(vreinterpretq_s16_s64(a), vdupq_n_s16(0))));
 }
@@ -1083,43 +1048,43 @@ VECMATH_FINLINE vec4i v_cvt_byte_vec4i(vec4i a)
 #define v_srai(v, bits) vshrq_n_s32(v, bits)
 
 #else
-VECMATH_FINLINE vec4i VECTORCALL v_slli(vec4i v, int bits) { return (int32x4_t)vshlq_n_u32((uint32x4_t)v, bits); }
-VECMATH_FINLINE vec4i VECTORCALL v_srli(vec4i v, int bits) { return (int32x4_t)vshrq_n_u32((uint32x4_t)v, bits); }
-VECMATH_FINLINE vec4i VECTORCALL v_srai(vec4i v, int bits) { return vshrq_n_s32(v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_slli(vec4i v, int bits) { return (int32x4_t)vshlq_n_u32((uint32x4_t)v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_srli(vec4i v, int bits) { return (int32x4_t)vshrq_n_u32((uint32x4_t)v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_srai(vec4i v, int bits) { return vshrq_n_s32(v, bits); }
 #endif
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, int bits)
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits)
 {
   if (bits & ~31)
     return v_zero();
   return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(bits)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, int bits)
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits)
 {
   if (bits & ~31)
     return v_zero();
   return vreinterpretq_s64_s32(vshlq_u32(vreinterpretq_s32_s64(v), vdupq_n_s32(-bits)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, int bits)
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits)
 {
   if (bits & ~31)
     return v_cmp_lti(v, v_zeroi());
   return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(-bits)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, vec4i bits)
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits)
 {
   int64_t c = (int64_t)vget_low_s64(bits);
   if (c & ~31)
     return v_zero();
   return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(c)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, vec4i bits)
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits)
 {
   int64_t c = (int64_t)vget_low_s64(bits);
   if (c & ~31)
     return v_zero();
   return vreinterpretq_s64_s32(vshlq_u32(vreinterpretq_s32_s64(v), vdupq_n_s32(-c)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, vec4i bits)
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits)
 {
   int64_t c = (int64_t)vget_low_s64(bits);
   if (c & ~31)
@@ -1127,34 +1092,34 @@ VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, vec4i bits)
   return vreinterpretq_s64_s32(vshlq_s32(vreinterpretq_s32_s64(v), vdupq_n_s32(-c)));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_sll(vec4i v, int bits) { return (int32x4_t)vshlq_u32((uint32x4_t)v, (int32x4_t)v_splatsi(bits)); }
-VECMATH_FINLINE vec4i VECTORCALL v_srl(vec4i v, int bits) { return (int32x4_t)vshlq_u32((uint32x4_t)v, (int32x4_t)v_splatsi(-bits)); }
-VECMATH_FINLINE vec4i VECTORCALL v_sra(vec4i v, int bits) { return vshlq_s32(v, (int32x4_t)v_splatsi(-bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_sll(vec4i v, int bits) { return (int32x4_t)vshlq_u32((uint32x4_t)v, (int32x4_t)v_splatsi(bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_srl(vec4i v, int bits) { return (int32x4_t)vshlq_u32((uint32x4_t)v, (int32x4_t)v_splatsi(-bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_sra(vec4i v, int bits) { return vshlq_s32(v, (int32x4_t)v_splatsi(-bits)); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_ori(vec4i a, vec4i b) { return vorrq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_andi(vec4i a, vec4i b) { return vandq_s32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_andnoti(vec4i a, vec4i b) { return vandq_s32(vmvnq_s32(a), b); }
-VECMATH_FINLINE vec4i VECTORCALL v_xori(vec4i a, vec4i b) { return veorq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_ori(vec4i a, vec4i b) { return vorrq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_andi(vec4i a, vec4i b) { return vandq_s32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_andnoti(vec4i a, vec4i b) { return vandq_s32(vmvnq_s32(a), b); }
+VECTORCALL VECMATH_FINLINE vec4i v_xori(vec4i a, vec4i b) { return veorq_s32(a, b); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a, vec4i b) { return vreinterpretq_s32_s16(vcombine_s16(vqmovn_s32(a), vqmovn_s32(b))); }
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a) { int16x4_t w = vqmovn_s32(a); return vreinterpretq_s32_s16(vcombine_s16(w, w)); }
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a, vec4i b) { return vreinterpretq_s32_s16(vcombine_s16(vqmovn_s32(a), vqmovn_s32(b))); }
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a) { int16x4_t w = vqmovn_s32(a); return vreinterpretq_s32_s16(vcombine_s16(w, w)); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a, vec4i b)
 {
   return vreinterpretq_s32_u16(vcombine_u16(vqmovun_s32(a), vqmovun_s32(b)));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a)
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a)
 {
   uint16x4_t w = vqmovun_s32(a);
   return vreinterpretq_s32_u16(vcombine_u16(w, w));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a, vec4i b)
 {
   return vreinterpretq_s32_u8(
     vcombine_u8(vqmovun_s16(vreinterpretq_s16_s32(a)),
       vqmovun_s16(vreinterpretq_s16_s32(b))));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a)
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a)
 {
   uint8x8_t t = vqmovun_s16(vreinterpretq_s16_s32(a));
   return vreinterpretq_s32_u8(vcombine_u8(t,t));

--- a/dag_vecMath_pc_sse.h
+++ b/dag_vecMath_pc_sse.h
@@ -43,21 +43,21 @@
   #pragma warning(disable: 4714) //function marked as __forceinline not inlined
 
   #if _MSC_VER < 1500
-  VECMATH_FINLINE __m128i VECTORCALL _mm_castps_si128(__m128  v) { return *(__m128i*)&v; }
-  VECMATH_FINLINE __m128 VECTORCALL  _mm_castsi128_ps(__m128i v) { return *(__m128 *)&v; }
+  VECTORCALL VECMATH_FINLINE __m128i _mm_castps_si128(__m128  v) { return *(__m128i*)&v; }
+  VECTORCALL VECMATH_FINLINE __m128  _mm_castsi128_ps(__m128i v) { return *(__m128 *)&v; }
   #endif
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_zero() { return _mm_setzero_ps(); }
-VECMATH_FINLINE vec4i VECTORCALL v_zeroi() { return _mm_setzero_si128(); }
-VECMATH_FINLINE vec4f VECTORCALL v_set_all_bits() { vec4f u = _mm_undefined_ps(); return v_cmp_eq(u, u); }
-VECMATH_FINLINE vec4i VECTORCALL v_set_all_bitsi() { vec4i u = _mm_undefined_si128(); return v_cmp_eqi(u, u); }
-VECMATH_FINLINE vec4f VECTORCALL v_msbit() { return (vec4f&)V_CI_SIGN_MASK; }
-VECMATH_FINLINE vec4f VECTORCALL v_splat4(const float *a) { return _mm_load1_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_splats(float a) {return _mm_set1_ps(a);}//_mm_set_ps1(a) is slower...
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi(int a) {return _mm_set1_epi32(a);}
-VECMATH_FINLINE vec4f VECTORCALL v_set_x(float a) {return _mm_set_ss(a);} // set x, zero others
-VECMATH_FINLINE vec4i VECTORCALL v_seti_x(int a) {return _mm_cvtsi32_si128(a);} // set x, zero others
+VECTORCALL VECMATH_FINLINE vec4f v_zero() { return _mm_setzero_ps(); }
+VECTORCALL VECMATH_FINLINE vec4i v_zeroi() { return _mm_setzero_si128(); }
+VECTORCALL VECMATH_FINLINE vec4f v_set_all_bits() { vec4f u = _mm_undefined_ps(); return v_cmp_eq(u, u); }
+VECTORCALL VECMATH_FINLINE vec4i v_set_all_bitsi() { vec4i u = _mm_undefined_si128(); return v_cmp_eqi(u, u); }
+VECTORCALL VECMATH_FINLINE vec4f v_msbit() { return (vec4f&)V_CI_SIGN_MASK; }
+VECTORCALL VECMATH_FINLINE vec4f v_splat4(const float *a) { return _mm_load1_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_splats(float a) {return _mm_set1_ps(a);}//_mm_set_ps1(a) is slower...
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi(int a) {return _mm_set1_epi32(a);}
+VECTORCALL VECMATH_FINLINE vec4f v_set_x(float a) {return _mm_set_ss(a);} // set x, zero others
+VECTORCALL VECMATH_FINLINE vec4i v_seti_x(int a) {return _mm_cvtsi32_si128(a);} // set x, zero others
 
 
 #if defined(DAGOR_ASAN_ENABLED) && defined(__GNUC__) && __GNUC__ >= 7
@@ -74,90 +74,90 @@ NO_ASAN_INLINE vec4i v_ldui(const int *m) { return _mm_loadu_si128((const vec4i*
 NO_ASAN_INLINE vec4f v_ldu_x(const float *m) { return _mm_load_ss(m); } // load x, zero others
 #endif
 
-VECMATH_FINLINE vec4i VECTORCALL v_ldush(const signed short *m)
+VECTORCALL VECMATH_FINLINE vec4i v_ldush(const signed short *m)
 {
   vec4i h = _mm_loadl_epi64((__m128i const*)m);
   vec4i sx = _mm_cmplt_epi16(h, _mm_setzero_si128());
   return _mm_unpacklo_epi16(h, sx);
 }
-VECMATH_FINLINE vec4i VECTORCALL v_lduush(const unsigned short *m)
+VECTORCALL VECMATH_FINLINE vec4i v_lduush(const unsigned short *m)
 {
   vec4i h = _mm_loadl_epi64((__m128i const*)m);
   return _mm_unpacklo_epi16(h, _mm_setzero_si128());
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_ldui_half(const void *m) { return _mm_loadl_epi64((__m128i const*)m); }
-VECMATH_FINLINE vec4f VECTORCALL v_ldu_half(const void *m) { return v_cast_vec4f(v_ldui_half(m)); }
+VECTORCALL VECMATH_FINLINE vec4i v_ldui_half(const void *m) { return _mm_loadl_epi64((__m128i const*)m); }
+VECTORCALL VECMATH_FINLINE vec4f v_ldu_half(const void *m) { return v_cast_vec4f(v_ldui_half(m)); }
 VECMATH_FINLINE void v_prefetch(const void *m) { _mm_prefetch((const char *)m, _MM_HINT_T0); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_lo_ush_vec4i(vec4i a) { return _mm_unpacklo_epi16(a, _mm_setzero_si128()); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_hi_ush_vec4i(vec4i a) { return _mm_unpackhi_epi16(a, _mm_setzero_si128()); }
-VECMATH_FINLINE vec4i VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_lo_ush_vec4i(vec4i a) { return _mm_unpacklo_epi16(a, _mm_setzero_si128()); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_hi_ush_vec4i(vec4i a) { return _mm_unpackhi_epi16(a, _mm_setzero_si128()); }
+VECTORCALL VECMATH_FINLINE vec4i
   v_cvt_lo_ssh_vec4i(vec4i a) { vec4i sx = _mm_cmplt_epi16(a, _mm_setzero_si128()); return _mm_unpacklo_epi16(a, sx); }
-VECMATH_FINLINE vec4i VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4i
   v_cvt_hi_ssh_vec4i(vec4i a) { vec4i sx = _mm_cmplt_epi16(a, _mm_setzero_si128()); return _mm_unpackhi_epi16(a, sx); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_byte_vec4i(vec4i a) { return _mm_unpacklo_epi8(a, _mm_setzero_si128()); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_byte_vec4i(vec4i a) { return _mm_unpacklo_epi8(a, _mm_setzero_si128()); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec4f(float x, float y, float z, float w)
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec4f(float x, float y, float z, float w)
 { return _mm_setr_ps(x, y, z, w); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_make_vec4i(int x, int y, int z, int w)
+VECTORCALL VECMATH_FINLINE vec4i v_make_vec4i(int x, int y, int z, int w)
 { return _mm_setr_epi32(x, y, z, w); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(float x, float y, float z)
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(float x, float y, float z)
 { return _mm_setr_ps(x, y, z, z); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_make_vec3f(vec4f x, vec4f y, vec4f z)
+VECTORCALL VECMATH_FINLINE vec4f v_make_vec3f(vec4f x, vec4f y, vec4f z)
 { return _mm_shuffle_ps(_mm_shuffle_ps(x, y, _MM_SHUFFLE(0, 0, 0, 0)), z, _MM_SHUFFLE(0, 0, 2, 0)); }
 
-//VECMATH_FINLINE vec4f VECTORCALL v_perm_mask(){ _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(a), mask)); }
+//VECTORCALL VECMATH_FINLINE vec4f v_perm_mask(){ _mm_castsi128_ps(_mm_shuffle_epi32(_mm_castps_si128(a), mask)); }
 #define V_SHUFFLE(v, mask) _mm_shuffle_ps(v, v, mask)
 #define V_SHUFFLE_REV(v, maskW, maskZ, maskY, maskX) V_SHUFFLE(v, _MM_SHUFFLE(maskW, maskZ, maskY, maskX))
 #define V_SHUFFLE_FWD(v, maskX, maskY, maskZ, maskW) V_SHUFFLE(v, _MM_SHUFFLE(maskW, maskZ, maskY, maskX))
 
 #if _TARGET_SIMD_SSE >=3
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxzz(vec4f b){ return _mm_moveldup_ps(b); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyxy(vec4f b){ return _mm_castpd_ps(_mm_movedup_pd(_mm_castps_pd(b))); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f b){ return _mm_moveldup_ps(b); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f b){ return _mm_castpd_ps(_mm_movedup_pd(_mm_castps_pd(b))); }
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxzz(vec4f b){ return V_SHUFFLE_FWD(b, 0,0, 2,2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyxy(vec4f b){ return V_SHUFFLE_FWD(b, 0,1, 0,1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxzz(vec4f b){ return V_SHUFFLE_FWD(b, 0,0, 2,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyxy(vec4f b){ return V_SHUFFLE_FWD(b, 0,1, 0,1); }
 #endif
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yyww(vec4f b){ return V_SHUFFLE_FWD(b, 1,1, 3,3); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzxz(vec4f b){ return V_SHUFFLE_FWD(b, 0,2,0,2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwzw(vec4f b){ return V_SHUFFLE_FWD(b, 2,3, 2,3); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywyw(vec4f b){ return V_SHUFFLE_FWD(b, 1,3,1,3); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzz(vec4f b){ return V_SHUFFLE_FWD(b, 0,1,2,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yyww(vec4f b){ return V_SHUFFLE_FWD(b, 1,1, 3,3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzxz(vec4f b){ return V_SHUFFLE_FWD(b, 0,2,0,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwzw(vec4f b){ return V_SHUFFLE_FWD(b, 2,3, 2,3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywyw(vec4f b){ return V_SHUFFLE_FWD(b, 1,3,1,3); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzz(vec4f b){ return V_SHUFFLE_FWD(b, 0,1,2,2); }
 
 
-VECMATH_FINLINE vec4f VECTORCALL v_splat_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_splat_x(vec4f a)
   { return _mm_shuffle_ps(a, a, _MM_SHUFFLE(0, 0, 0, 0));  }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_y(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_splat_y(vec4f a)
   { return _mm_shuffle_ps(a, a, _MM_SHUFFLE(1, 1, 1, 1));  }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_z(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_splat_z(vec4f a)
   { return _mm_shuffle_ps(a, a, _MM_SHUFFLE(2, 2, 2, 2));  }
-VECMATH_FINLINE vec4f VECTORCALL v_splat_w(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_splat_w(vec4f a)
   { return _mm_shuffle_ps(a, a, _MM_SHUFFLE(3, 3, 3, 3));  }
 
-VECMATH_FINLINE vec4i VECTORCALL v_splat_xi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(0, 0, 0, 0));  }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_yi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(1, 1, 1, 1));  }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_zi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(2, 2, 2, 2));  }
-VECMATH_FINLINE vec4i VECTORCALL v_splat_wi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(3, 3, 3, 3));  }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_xi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(0, 0, 0, 0));  }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_yi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(1, 1, 1, 1));  }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_zi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(2, 2, 2, 2));  }
+VECTORCALL VECMATH_FINLINE vec4i v_splat_wi(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(3, 3, 3, 3));  }
 
-VECMATH_FINLINE void VECTORCALL v_st(void *m, vec4f v) { _mm_store_ps((float*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stu(void *m, vec4f v) { _mm_storeu_ps((float*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_sti(void *m, vec4i v) { _mm_store_si128((__m128i*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stui(void *m, vec4i v) { _mm_storeu_si128((__m128i*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stui_half(void *m, vec4i v) { _mm_storel_epi64((__m128i*)m, v); }
-VECMATH_FINLINE void VECTORCALL v_stu_half(void *m, vec4f v) { _mm_storel_epi64((__m128i*)m, _mm_castps_si128(v)); }
-VECMATH_FINLINE void VECTORCALL v_stu_p3(float *p3, vec3f v) { _mm_storel_pi((__m64*)p3, v); p3[2] = v_extract_z(v); } //-V1032
+VECTORCALL VECMATH_FINLINE void v_st(void *m, vec4f v) { _mm_store_ps((float*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stu(void *m, vec4f v) { _mm_storeu_ps((float*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_sti(void *m, vec4i v) { _mm_store_si128((__m128i*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stui(void *m, vec4i v) { _mm_storeu_si128((__m128i*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stui_half(void *m, vec4i v) { _mm_storel_epi64((__m128i*)m, v); }
+VECTORCALL VECMATH_FINLINE void v_stu_half(void *m, vec4f v) { _mm_storel_epi64((__m128i*)m, _mm_castps_si128(v)); }
+VECTORCALL VECMATH_FINLINE void v_stu_p3(float *p3, vec3f v) { _mm_storel_pi((__m64*)p3, v); p3[2] = v_extract_z(v); } //-V1032
 
-VECMATH_FINLINE vec4f VECTORCALL v_merge_hw(vec4f a, vec4f b) { return _mm_unpacklo_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_merge_lw(vec4f a, vec4f b) { return _mm_unpackhi_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_merge_hw(vec4f a, vec4f b) { return _mm_unpacklo_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_merge_lw(vec4f a, vec4f b) { return _mm_unpackhi_ps(a, b); }
 
-VECMATH_FINLINE int VECTORCALL v_signmask(vec4f a) { return _mm_movemask_ps(a); }
+VECTORCALL VECMATH_FINLINE int v_signmask(vec4f a) { return _mm_movemask_ps(a); }
 
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_zeros(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_zeros(vec4f a)
 {
 #if _TARGET_SIMD_SSE >= 4
   return _mm_test_all_zeros(v_cast_vec4i(a), v_cast_vec4i(a));
@@ -167,7 +167,7 @@ VECMATH_FINLINE bool VECTORCALL v_test_all_bits_zeros(vec4f a)
 #endif
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_all_bits_ones(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_all_bits_ones(vec4f a)
 {
 #if _TARGET_SIMD_SSE >= 4
   return _mm_test_all_ones(v_cast_vec4i(a));
@@ -177,65 +177,65 @@ VECMATH_FINLINE bool VECTORCALL v_test_all_bits_ones(vec4f a)
 #endif
 }
 
-VECMATH_FINLINE bool VECTORCALL v_test_any_bit_set(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_test_any_bit_set(vec4f a)
 {
   return !v_test_all_bits_zeros(a);
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyzw_all_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyzw_all_not_zeroi(vec4f a)
 {
   return v_signmask(v_cmp_eq(a, v_zero())) == 0;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_zeroi(vec4f a)
 {
   vec4f notZeroMask = v_cmp_neq(a, v_zero());
   return (v_signmask(notZeroMask) & 7) == 0;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_all_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_all_not_zeroi(vec4f a)
 {
   vec4f zeroMask = v_cmp_eq(a, v_zero());
   return (v_signmask(zeroMask) & 7) == 0;
 }
 
-VECMATH_FINLINE bool VECTORCALL v_check_xyz_any_not_zeroi(vec4f a)
+VECTORCALL VECMATH_FINLINE bool v_check_xyz_any_not_zeroi(vec4f a)
 {
   return !v_check_xyz_all_zeroi(a);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eq(vec4f a, vec4f b) { return _mm_cmpeq_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_neq(vec4f a, vec4f b) { return _mm_cmpneq_ps(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_eqi(vec4i a, vec4i b) { return _mm_cmpeq_epi32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_eqi(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eq(vec4f a, vec4f b) { return _mm_cmpeq_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_neq(vec4f a, vec4f b) { return _mm_cmpneq_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_eqi(vec4i a, vec4i b) { return _mm_cmpeq_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_eqi(vec4f a, vec4f b)
 {
   __m128i m = _mm_cmpeq_epi32(v_cast_vec4i(a), v_cast_vec4i(b));
   return v_cast_vec4f(m);
 }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_ge(vec4f a, vec4f b) { return _mm_cmpge_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_cmp_gt(vec4f a, vec4f b) { return _mm_cmpgt_ps(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_lti(vec4i a, vec4i b) { return _mm_cmplt_epi32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_cmp_gti(vec4i a, vec4i b) { return _mm_cmpgt_epi32(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_and(vec4f a, vec4f b) { return _mm_and_ps(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_andnot(vec4f a, vec4f b) { return _mm_andnot_ps(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_or(vec4f a, vec4f b) { return _mm_or_ps(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_xor(vec4f a, vec4f b) { return _mm_xor_ps(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_not(vec4f v) { return v_xor(v, v_set_all_bits()); }
-VECMATH_FINLINE vec4f VECTORCALL v_btsel(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_ge(vec4f a, vec4f b) { return _mm_cmpge_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_cmp_gt(vec4f a, vec4f b) { return _mm_cmpgt_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_lti(vec4i a, vec4i b) { return _mm_cmplt_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_cmp_gti(vec4i a, vec4i b) { return _mm_cmpgt_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_and(vec4f a, vec4f b) { return _mm_and_ps(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_andnot(vec4f a, vec4f b) { return _mm_andnot_ps(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_or(vec4f a, vec4f b) { return _mm_or_ps(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_xor(vec4f a, vec4f b) { return _mm_xor_ps(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_not(vec4f v) { return v_xor(v, v_set_all_bits()); }
+VECTORCALL VECMATH_FINLINE vec4f v_btsel(vec4f a, vec4f b, vec4f c)
 {
   return _mm_or_ps(_mm_and_ps(c, b), _mm_andnot_ps(c, a));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_btseli(vec4i a, vec4i b, vec4i c)
+VECTORCALL VECMATH_FINLINE vec4i v_btseli(vec4i a, vec4i b, vec4i c)
 {
   return _mm_or_si128(_mm_and_si128(c, b), _mm_andnot_si128(c, a));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cast_vec4i(vec4f a) {return _mm_castps_si128(a);}//no instruction
-VECMATH_FINLINE vec4f VECTORCALL v_cast_vec4f(vec4i a) {return _mm_castsi128_ps(a);}//no instruction
+VECTORCALL VECMATH_FINLINE vec4i v_cast_vec4i(vec4f a) {return _mm_castps_si128(a);}//no instruction
+VECTORCALL VECMATH_FINLINE vec4f v_cast_vec4f(vec4i a) {return _mm_castsi128_ps(a);}//no instruction
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvti_vec4i(vec4f a) { return _mm_cvttps_epi32(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_cvti_vec4i(vec4f a) { return _mm_cvttps_epi32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i(vec4f a)
 {
 #if defined(__AVX512F_)//only works on clang/gcc
   return _mm_cvtps_epu32(v);
@@ -252,7 +252,7 @@ VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i(vec4f a)
 #endif
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i_ieee(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i v_cvtu_vec4i_ieee(vec4f a)
 {
 #if defined(__AVX512F_)//only works on clang/gcc
   return _mm_cvtps_epu32(v);
@@ -264,8 +264,8 @@ VECMATH_FINLINE vec4i VECTORCALL v_cvtu_vec4i_ieee(vec4f a)
 #endif
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_cvti_vec4f(vec4i a) { return _mm_cvtepi32_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f(vec4i v)
+VECTORCALL VECMATH_FINLINE vec4f v_cvti_vec4f(vec4i a) { return _mm_cvtepi32_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f(vec4i v)
 {
 #if defined(__AVX512F_)//only works on clang/gcc
   return _mm_cvtepu32_ps(v);
@@ -278,7 +278,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f(vec4i v)
 #endif
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f_ieee(vec4i v)
+VECTORCALL VECMATH_FINLINE vec4f v_cvtu_vec4f_ieee(vec4i v)
 {
 #if defined(__AVX512F_)//only works on clang/gcc
   return _mm_cvtepu32_ps(v);
@@ -295,70 +295,70 @@ VECMATH_FINLINE vec4f VECTORCALL v_cvtu_vec4f_ieee(vec4i v)
 #endif
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_roundi(vec4f a)  { return _mm_cvtps_epi32(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_roundi(vec4f a)  { return _mm_cvtps_epi32(a); }
 
-VECMATH_FINLINE vec4i VECTORCALL sse2_cvt_floori(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i sse2_cvt_floori(vec4f a)
 {
   vec4i fi = _mm_cvttps_epi32(a);
   return _mm_sub_epi32(fi, v_cast_vec4i(_mm_and_ps(_mm_cmpgt_ps(_mm_cvtepi32_ps(fi), a), V_CI_1)));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL sse2_cvt_ceili(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4i sse2_cvt_ceili(vec4f a)
 {
   vec4i fi = _mm_cvttps_epi32(a);
   return _mm_add_epi32(fi, v_cast_vec4i(_mm_and_ps(_mm_cmplt_ps(_mm_cvtepi32_ps(fi), a), V_CI_1)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL sse2_floor(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f sse2_floor(vec4f a)
 {
   vec4f fi = _mm_cvtepi32_ps(_mm_cvttps_epi32(a));
   return _mm_sub_ps(fi, _mm_and_ps(_mm_cmpgt_ps(fi, a), V_C_ONE));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL sse2_ceil(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f sse2_ceil(vec4f a)
 {
   vec4f fi = _mm_cvtepi32_ps(_mm_cvttps_epi32(a));
   return _mm_add_ps(fi, _mm_and_ps(_mm_cmplt_ps(fi, a), V_C_ONE));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL sse2_round(vec4f a) { return _mm_cvtepi32_ps(_mm_cvtps_epi32(a)); }
+VECTORCALL VECMATH_FINLINE vec4f sse2_round(vec4f a) { return _mm_cvtepi32_ps(_mm_cvtps_epi32(a)); }
 
 #if _TARGET_SIMD_SSE >= 4 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE4_1__)
-VECMATH_FINLINE vec4f VECTORCALL sse4_floor(vec4f a) { return _mm_round_ps(a, _MM_FROUND_TO_NEG_INF|_MM_FROUND_NO_EXC); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_ceil(vec4f a) { return _mm_round_ps(a, _MM_FROUND_TO_POS_INF|_MM_FROUND_NO_EXC); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_round(vec4f a) { return _mm_round_ps(a, _MM_FROUND_RINT); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_floori(vec4f a) { return _mm_cvttps_epi32(sse4_floor(a)); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_ceili(vec4f a)  { return _mm_cvttps_epi32(sse4_ceil(a)); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_floor(vec4f a) { return _mm_round_ps(a, _MM_FROUND_TO_NEG_INF|_MM_FROUND_NO_EXC); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_ceil(vec4f a) { return _mm_round_ps(a, _MM_FROUND_TO_POS_INF|_MM_FROUND_NO_EXC); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_round(vec4f a) { return _mm_round_ps(a, _MM_FROUND_RINT); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_floori(vec4f a) { return _mm_cvttps_epi32(sse4_floor(a)); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_ceili(vec4f a)  { return _mm_cvttps_epi32(sse4_ceil(a)); }
 #else // fallback to SSE2
-VECMATH_FINLINE vec4f VECTORCALL sse4_floor(vec4f a) { return sse2_floor(a); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_ceil(vec4f a) { return sse2_ceil(a); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_round(vec4f a) { return sse2_round(a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_floori(vec4f a) { return sse2_cvt_floori(a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_cvt_ceili(vec4f a)  { return sse2_cvt_ceili(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_floor(vec4f a) { return sse2_floor(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_ceil(vec4f a) { return sse2_ceil(a); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_round(vec4f a) { return sse2_round(a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_floori(vec4f a) { return sse2_cvt_floori(a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_cvt_ceili(vec4f a)  { return sse2_cvt_ceili(a); }
 #endif
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_floori(vec4f a) {return sse4_cvt_floori(a);}
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a) {return sse4_cvt_ceili(a);}
-VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a) { return sse4_floor(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a) { return sse4_ceil(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a) { return sse4_round(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c) { return _mm_blendv_ps(a, b, c); }
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_floori(vec4f a) {return sse4_cvt_floori(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a) {return sse4_cvt_ceili(a);}
+VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a) { return sse4_floor(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a) { return sse4_ceil(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a) { return sse4_round(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c) { return _mm_blendv_ps(a, b, c); }
+VECTORCALL VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c)
 {
   return _mm_castps_si128(_mm_blendv_ps(_mm_castsi128_ps(a), _mm_castsi128_ps(b), _mm_castsi128_ps(c)));
 }
 #else
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_floori(vec4f a) {return sse2_cvt_floori(a);}
-VECMATH_FINLINE vec4i VECTORCALL v_cvt_ceili(vec4f a) {return sse2_cvt_ceili(a);}
-VECMATH_FINLINE vec4f VECTORCALL v_floor(vec4f a) { return sse2_floor(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_ceil(vec4f a) { return sse2_ceil(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_round(vec4f a) { return sse2_round(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sel(vec4f a, vec4f b, vec4f c)
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_floori(vec4f a) {return sse2_cvt_floori(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_cvt_ceili(vec4f a) {return sse2_cvt_ceili(a);}
+VECTORCALL VECMATH_FINLINE vec4f v_floor(vec4f a) { return sse2_floor(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_ceil(vec4f a) { return sse2_ceil(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_round(vec4f a) { return sse2_round(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sel(vec4f a, vec4f b, vec4f c)
 {
   vec4f m = _mm_castsi128_ps(_mm_srai_epi32(_mm_castps_si128(c), 31));
   return _mm_or_ps(_mm_and_ps(m, b), _mm_andnot_ps(m, a));
 }
-VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
+VECTORCALL VECMATH_FINLINE vec4i v_seli(vec4i a, vec4i b, vec4i c)
 {
   vec4i m = _mm_srai_epi32(c, 31);
   return _mm_or_si128(_mm_and_si128(m, b), _mm_andnot_si128(m, a));
@@ -366,39 +366,39 @@ VECMATH_FINLINE vec4i VECTORCALL v_seli(vec4i a, vec4i b, vec4i c)
 #endif
 
 
-VECMATH_FINLINE vec4f VECTORCALL v_add(vec4f a, vec4f b) { return _mm_add_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sub(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_mul(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_div(vec4f a, vec4f b) { return _mm_div_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add(vec4f a, vec4f b) { return _mm_add_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_sub(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_mul(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_div(vec4f a, vec4f b) { return _mm_div_ps(a, b); }
 #if defined(__FMA__) || defined(__AVX2__)
-VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); }
-VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); } // _ps is better
-VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
-VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_fmadd_ps(a, b, c); } // _ps is better
+VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
+VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_fmsub_ps(a, b, c); }
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_madd(vec4f a, vec4f b, vec4f c) { return _mm_add_ps(_mm_mul_ps(a, b), c); }
-VECMATH_FINLINE vec4f VECTORCALL v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_add_ss(_mm_mul_ss(a, b), c); }
-VECMATH_FINLINE vec4f VECTORCALL v_msub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(_mm_mul_ps(a, b), c); }
-VECMATH_FINLINE vec4f VECTORCALL v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(_mm_mul_ss(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd(vec4f a, vec4f b, vec4f c) { return _mm_add_ps(_mm_mul_ps(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_madd_x(vec4f a, vec4f b, vec4f c) { return _mm_add_ss(_mm_mul_ss(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_msub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(_mm_mul_ps(a, b), c); }
+VECTORCALL VECMATH_FINLINE vec4f v_msub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(_mm_mul_ss(a, b), c); }
 #endif
-VECMATH_FINLINE vec4f VECTORCALL v_nmsub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(c, _mm_mul_ps(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub(vec4f a, vec4f b, vec4f c) { return _mm_sub_ps(c, _mm_mul_ps(a, b)); }
 #ifdef __AVX__
 // On modern processors _ss/_ps versions of simple instructions have same performance,
 // but _ss version in avx have false dependency on .yzw when destination is write-only
-VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b) { return _mm_add_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { return _mm_add_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { return _mm_sub_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { return _mm_mul_ps(a, b); }
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_add_x(vec4f a, vec4f b) { return _mm_add_ss(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_sub_x(vec4f a, vec4f b) { return _mm_sub_ss(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_mul_x(vec4f a, vec4f b) { return _mm_mul_ss(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_add_x(vec4f a, vec4f b) { return _mm_add_ss(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_sub_x(vec4f a, vec4f b) { return _mm_sub_ss(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_mul_x(vec4f a, vec4f b) { return _mm_mul_ss(a, b); }
 #endif
-VECMATH_FINLINE vec4f VECTORCALL v_div_x(vec4f a, vec4f b) { return _mm_div_ss(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_nmsub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(c, _mm_mul_ss(a, b)); }
-VECMATH_FINLINE vec4i VECTORCALL v_addi(vec4i a, vec4i b) { return _mm_add_epi32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_subi(vec4i a, vec4i b) { return _mm_sub_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_div_x(vec4f a, vec4f b) { return _mm_div_ss(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_nmsub_x(vec4f a, vec4f b, vec4f c) { return _mm_sub_ss(c, _mm_mul_ss(a, b)); }
+VECTORCALL VECMATH_FINLINE vec4i v_addi(vec4i a, vec4i b) { return _mm_add_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_subi(vec4i a, vec4i b) { return _mm_sub_epi32(a, b); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_hadd4_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hadd4_x(vec4f a)
 {
 #if _TARGET_SIMD_SSE >= 3
   vec4f s = _mm_hadd_ps(a, a);
@@ -408,7 +408,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_hadd4_x(vec4f a)
   return v_add_x(s, v_splat_y(s));
 #endif
 }
-VECMATH_FINLINE vec4f VECTORCALL v_hadd3_x(vec3f a)
+VECTORCALL VECMATH_FINLINE vec4f v_hadd3_x(vec3f a)
 {
 #if _TARGET_SIMD_SSE >= 3
   vec4f s = _mm_hadd_ps(a, a);
@@ -419,35 +419,35 @@ VECMATH_FINLINE vec4f VECTORCALL v_hadd3_x(vec3f a)
 #endif
 }
 
-VECMATH_FINLINE vec4i VECTORCALL v_slli(vec4i v, int bits) {return _mm_slli_epi32(v, bits);}
-VECMATH_FINLINE vec4i VECTORCALL v_srli(vec4i v, int bits) {return _mm_srli_epi32(v, bits);}
-VECMATH_FINLINE vec4i VECTORCALL v_srai(vec4i v, int bits) {return _mm_srai_epi32(v, bits);}
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, int bits) { return _mm_sll_epi32(v, _mm_cvtsi32_si128(bits)); }
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, int bits) { return _mm_srl_epi32(v, _mm_cvtsi32_si128(bits)); }
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, int bits) { return _mm_sra_epi32(v, _mm_cvtsi32_si128(bits)); }
-VECMATH_FINLINE vec4i VECTORCALL v_slli_n(vec4i v, vec4i bits) { return _mm_sll_epi32(v, bits); }
-VECMATH_FINLINE vec4i VECTORCALL v_srli_n(vec4i v, vec4i bits) { return _mm_srl_epi32(v, bits); }
-VECMATH_FINLINE vec4i VECTORCALL v_srai_n(vec4i v, vec4i bits) { return _mm_sra_epi32(v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_slli(vec4i v, int bits) {return _mm_slli_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_srli(vec4i v, int bits) {return _mm_srli_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_srai(vec4i v, int bits) {return _mm_srai_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, int bits) { return _mm_sll_epi32(v, _mm_cvtsi32_si128(bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, int bits) { return _mm_srl_epi32(v, _mm_cvtsi32_si128(bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, int bits) { return _mm_sra_epi32(v, _mm_cvtsi32_si128(bits)); }
+VECTORCALL VECMATH_FINLINE vec4i v_slli_n(vec4i v, vec4i bits) { return _mm_sll_epi32(v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_srli_n(vec4i v, vec4i bits) { return _mm_srl_epi32(v, bits); }
+VECTORCALL VECMATH_FINLINE vec4i v_srai_n(vec4i v, vec4i bits) { return _mm_sra_epi32(v, bits); }
 
-VECMATH_FINLINE vec4i VECTORCALL v_sll(vec4i v, int bits) {return _mm_slli_epi32(v, bits);}
-VECMATH_FINLINE vec4i VECTORCALL v_srl(vec4i v, int bits) {return _mm_srli_epi32(v, bits);}
-VECMATH_FINLINE vec4i VECTORCALL v_sra(vec4i v, int bits) {return _mm_srai_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_sll(vec4i v, int bits) {return _mm_slli_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_srl(vec4i v, int bits) {return _mm_srli_epi32(v, bits);}
+VECTORCALL VECMATH_FINLINE vec4i v_sra(vec4i v, int bits) {return _mm_srai_epi32(v, bits);}
 
-VECMATH_FINLINE vec4i VECTORCALL v_ori(vec4i a, vec4i b) {return _mm_or_si128(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_andi(vec4i a, vec4i b) {return _mm_and_si128(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_andnoti(vec4i a, vec4i b) {return _mm_andnot_si128(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_xori(vec4i a, vec4i b){return _mm_xor_si128(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_ori(vec4i a, vec4i b) {return _mm_or_si128(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_andi(vec4i a, vec4i b) {return _mm_and_si128(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_andnoti(vec4i a, vec4i b) {return _mm_andnot_si128(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_xori(vec4i a, vec4i b){return _mm_xor_si128(a, b);}
 
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a, vec4i b){return _mm_packs_epi32(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_packs(vec4i a){return _mm_packs_epi32(a, a);}
-VECMATH_FINLINE vec4i VECTORCALL sse2_packus(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a, vec4i b){return _mm_packs_epi32(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_packs(vec4i a){return _mm_packs_epi32(a, a);}
+VECTORCALL VECMATH_FINLINE vec4i sse2_packus(vec4i a, vec4i b)
 {
   vec4i z = _mm_setzero_si128();
   a = v_andi(v_ori(v_srai(v_slli(a, 16), 16), _mm_cmpgt_epi32(v_srli(a, 16), z)), _mm_cmpgt_epi32(a, z));
   b = v_andi(v_ori(v_srai(v_slli(b, 16), 16), _mm_cmpgt_epi32(v_srli(b, 16), z)), _mm_cmpgt_epi32(b, z));
   return _mm_packs_epi32(a, b);
 }
-VECMATH_FINLINE vec4i VECTORCALL sse2_packus(vec4i a)
+VECTORCALL VECMATH_FINLINE vec4i sse2_packus(vec4i a)
 {
   vec4i z = _mm_setzero_si128();
   a = v_andi(v_ori(v_srai(v_slli(a, 16), 16), _mm_cmpgt_epi32(v_srli(a, 16), z)), _mm_cmpgt_epi32(a, z));
@@ -455,7 +455,7 @@ VECMATH_FINLINE vec4i VECTORCALL sse2_packus(vec4i a)
 }
 
 //unsigned mul
-VECMATH_FINLINE vec4i VECTORCALL sse2_muli(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i sse2_muli(vec4i a, vec4i b)
 {
   __m128i tmp1 = _mm_mul_epu32(a,b); /* mul 2,0*/
   __m128i tmp2 = _mm_mul_epu32( _mm_srli_si128(a,4), _mm_srli_si128(b,4)); /* mul 3,1 */
@@ -463,76 +463,85 @@ VECMATH_FINLINE vec4i VECTORCALL sse2_muli(vec4i a, vec4i b)
 }
 
 #if _TARGET_SIMD_SSE >= 4 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE4_1__)
-VECMATH_FINLINE vec4i VECTORCALL sse4_packus(vec4i a, vec4i b) { return _mm_packus_epi32(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_packus(vec4i a) { return _mm_packus_epi32(a, a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_muli(vec4i a, vec4i b) { return _mm_mullo_epi32(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_packus(vec4i a, vec4i b) { return _mm_packus_epi32(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_packus(vec4i a) { return _mm_packus_epi32(a, a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_muli(vec4i a, vec4i b) { return _mm_mullo_epi32(a, b);}
 #else // fallback to SSE2
-VECMATH_FINLINE vec4i VECTORCALL sse4_packus(vec4i a, vec4i b) { return sse2_packus(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_packus(vec4i a) { return sse2_packus(a); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_muli(vec4i a, vec4i b) { return sse2_muli(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_packus(vec4i a, vec4i b) { return sse2_packus(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_packus(vec4i a) { return sse2_packus(a); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_muli(vec4i a, vec4i b) { return sse2_muli(a, b);}
 #endif
 
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a, vec4i b) { return sse4_packus(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a) { return sse4_packus(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_muli(vec4i a, vec4i b) { return sse4_muli(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a, vec4i b) { return sse4_packus(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a) { return sse4_packus(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b) { return sse4_muli(a,b); }
 #else
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a, vec4i b) { return sse2_packus(a, b); }
-VECMATH_FINLINE vec4i VECTORCALL v_packus(vec4i a) { return sse2_packus(a); }
-VECMATH_FINLINE vec4i VECTORCALL v_muli(vec4i a, vec4i b) { return sse2_muli(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a, vec4i b) { return sse2_packus(a, b); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus(vec4i a) { return sse2_packus(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_muli(vec4i a, vec4i b) { return sse2_muli(a,b); }
 #endif
 
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a, vec4i b) { return _mm_packus_epi16(a,b); }
-VECMATH_FINLINE vec4i VECTORCALL v_packus16(vec4i a) { return _mm_packus_epi16(a,a); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a, vec4i b) { return _mm_packus_epi16(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i v_packus16(vec4i a) { return _mm_packus_epi16(a,a); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est(vec4f a) { return _mm_rcp_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est(vec4f a) { return _mm_rcp_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rcp(vec4f a)
 {
   __m128 y0 = _mm_rcp_ps(a);
   return _mm_sub_ps(_mm_add_ps(y0, y0), _mm_mul_ps(a, _mm_mul_ps(y0, y0)));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_est_x(vec4f a) { return _mm_rcp_ss(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rcp_x(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_est_x(vec4f a) { return _mm_rcp_ss(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rcp_x(vec4f a)
 {
   __m128 y0 = _mm_rcp_ss(a);
   return _mm_sub_ss(_mm_add_ss(y0, y0), _mm_mul_ss(a, _mm_mul_ss(y0, y0)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4_fast(vec4f a) { return _mm_rsqrt_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt4(vec4f a) { return v_rcp(_mm_sqrt_ps(a)); }
-
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_fast_x(vec4f a) { return _mm_rsqrt_ss(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_rsqrt_x(vec4f a) // Reciprocal square root estimate and 1 Newton-Raphson iteration.
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4_fast(vec4f a) { return _mm_rsqrt_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt4(vec4f a)
 {
-  vec4f y0, y0x, y0half;
-  y0 = v_rsqrt_fast_x(a);
-  y0x = v_mul_x(y0, a);
-  y0half = v_mul_x(y0, V_C_HALF);
-  return v_madd_x(v_nmsub_x(y0, y0x, V_C_ONE), y0half, y0);
+  vec4f r = v_rsqrt4_fast(a);
+  a = v_mul(a, r);
+  a = v_mul(a, r);
+  a = v_add(a, v_splats(-3.0f));
+  r = v_mul(r, v_splats(-0.5f));
+  return v_mul(a, r);
 }
-VECMATH_FINLINE vec4i VECTORCALL sse2_mini(vec4i a, vec4i b)
+
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_fast_x(vec4f a) { return _mm_rsqrt_ss(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_rsqrt_x(vec4f a) // Reciprocal square root estimate and 1 Newton-Raphson iteration.
+{
+  vec4f r = v_rsqrt_fast_x(a);
+  a = v_mul_x(a, r);
+  a = v_mul_x(a, r);
+  a = v_add_x(a, v_set_x(-3.0f));
+  r = v_mul_x(r, v_set_x(-0.5f));
+  return v_mul_x(a, r);
+}
+VECTORCALL VECMATH_FINLINE vec4i sse2_mini(vec4i a, vec4i b)
 {
   vec4i cond = v_cmp_gti(a, b);
   return v_ori(v_andnoti(cond, a), v_andi(cond, b));
 }
-VECMATH_FINLINE vec4i VECTORCALL sse2_maxi(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i sse2_maxi(vec4i a, vec4i b)
 {
   vec4i cond = v_cmp_gti(b, a);
   return v_ori(v_andnoti(cond, a), v_andi(cond, b));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL sse2_minu(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i sse2_minu(vec4i a, vec4i b)
 {
   vec4i cond = v_cmp_gti(v_subi(a, V_CI_SIGN_MASK), v_subi(b, V_CI_SIGN_MASK));
   return v_ori(v_andnoti(cond, a), v_andi(cond, b));
 }
-VECMATH_FINLINE vec4i VECTORCALL sse2_maxu(vec4i a, vec4i b)
+VECTORCALL VECMATH_FINLINE vec4i sse2_maxu(vec4i a, vec4i b)
 {
   vec4i cond = v_cmp_lti(v_subi(a, V_CI_SIGN_MASK), v_subi(b, V_CI_SIGN_MASK));
   return v_ori(v_andnoti(cond, a), v_andi(cond, b));
 }
 
-VECMATH_FINLINE vec4i VECTORCALL sse2_absi (vec4i a)
+VECTORCALL VECMATH_FINLINE vec4i sse2_absi (vec4i a)
 {
   vec4i mask = v_cmp_lti( a, _mm_setzero_si128() ); // FFFF   where a < 0
   a    = v_xori ( a, mask );                         // Invert where a < 0
@@ -542,42 +551,42 @@ VECMATH_FINLINE vec4i VECTORCALL sse2_absi (vec4i a)
 }
 
 #if _TARGET_SIMD_SSE >= 3 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE3__)
-VECMATH_FINLINE vec4i VECTORCALL sse3_absi(vec4i a) {return _mm_abs_epi32(a);}
+VECTORCALL VECMATH_FINLINE vec4i sse3_absi(vec4i a) {return _mm_abs_epi32(a);}
 #else
-VECMATH_FINLINE vec4i VECTORCALL sse3_absi(vec4i a) {return sse2_absi(a);}
+VECTORCALL VECMATH_FINLINE vec4i sse3_absi(vec4i a) {return sse2_absi(a);}
 #endif
 
 #if _TARGET_SIMD_SSE >= 4 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE4_1__)
-VECMATH_FINLINE vec4i VECTORCALL sse4_mini(vec4i a, vec4i b) {return _mm_min_epi32(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL sse4_maxi(vec4i a, vec4i b) {return _mm_max_epi32(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL sse4_maxu(vec4i a, vec4i b) { return _mm_max_epu32(a,b); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_minu(vec4i a, vec4i b) { return _mm_min_epu32(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_mini(vec4i a, vec4i b) {return _mm_min_epi32(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_maxi(vec4i a, vec4i b) {return _mm_max_epi32(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_maxu(vec4i a, vec4i b) { return _mm_max_epu32(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_minu(vec4i a, vec4i b) { return _mm_min_epu32(a,b); }
 #else // fallback to SSE2
-VECMATH_FINLINE vec4i VECTORCALL sse4_mini(vec4i a, vec4i b) {return sse2_mini(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL sse4_maxi(vec4i a, vec4i b) {return sse2_maxi(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL sse4_maxu(vec4i a, vec4i b) { return sse2_maxu(a,b); }
-VECMATH_FINLINE vec4i VECTORCALL sse4_minu(vec4i a, vec4i b) { return sse2_minu(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_mini(vec4i a, vec4i b) {return sse2_mini(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_maxi(vec4i a, vec4i b) {return sse2_maxi(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i sse4_maxu(vec4i a, vec4i b) { return sse2_maxu(a,b); }
+VECTORCALL VECMATH_FINLINE vec4i sse4_minu(vec4i a, vec4i b) { return sse2_minu(a,b); }
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_min(vec4f a, vec4f b) { return _mm_min_ps(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL v_max(vec4f a, vec4f b) { return _mm_max_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_min(vec4f a, vec4f b) { return _mm_min_ps(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f v_max(vec4f a, vec4f b) { return _mm_max_ps(a, b); }
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE vec4i VECTORCALL v_mini(vec4i a, vec4i b) {return sse4_mini(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_maxi(vec4i a, vec4i b) {return sse4_maxi(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_minu(vec4i a, vec4i b) {return sse4_minu(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_maxu(vec4i a, vec4i b) {return sse4_maxu(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_absi(vec4i a) {return sse3_absi(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b) {return sse4_mini(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b) {return sse4_maxi(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b) {return sse4_minu(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b) {return sse4_maxu(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a) {return sse3_absi(a);}
 #else
-VECMATH_FINLINE vec4i VECTORCALL v_mini(vec4i a, vec4i b) {return sse2_mini(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_maxi(vec4i a, vec4i b) {return sse2_maxi(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_minu(vec4i a, vec4i b) {return sse2_minu(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_maxu(vec4i a, vec4i b) {return sse2_maxu(a, b);}
-VECMATH_FINLINE vec4i VECTORCALL v_absi(vec4i a) {return sse2_absi(a);}
+VECTORCALL VECMATH_FINLINE vec4i v_mini(vec4i a, vec4i b) {return sse2_mini(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_maxi(vec4i a, vec4i b) {return sse2_maxi(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_minu(vec4i a, vec4i b) {return sse2_minu(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_maxu(vec4i a, vec4i b) {return sse2_maxu(a, b);}
+VECTORCALL VECMATH_FINLINE vec4i v_absi(vec4i a) {return sse2_absi(a);}
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_neg(vec4f a) {return v_xor(a, v_cast_vec4f(v_splatsi(0x80000000)));}
-VECMATH_FINLINE vec4i VECTORCALL v_negi(vec4i a){ return v_subi(v_cast_vec4i(v_zero()), a); }
-VECMATH_FINLINE vec4f VECTORCALL v_abs(vec4f a)
+VECTORCALL VECMATH_FINLINE vec4f v_neg(vec4f a) {return v_xor(a, v_cast_vec4f(v_splatsi(0x80000000)));}
+VECTORCALL VECMATH_FINLINE vec4i v_negi(vec4i a){ return v_subi(v_cast_vec4i(v_zero()), a); }
+VECTORCALL VECMATH_FINLINE vec4f v_abs(vec4f a)
 {
   #if defined(__clang__)
     return v_max(v_neg(a), a);
@@ -590,111 +599,111 @@ VECMATH_FINLINE vec4f VECTORCALL v_abs(vec4f a)
   #endif
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4_fast(vec4f a) { return _mm_sqrt_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt4(vec4f a) { return _mm_sqrt_ps(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_fast_x(vec4f a) { return _mm_sqrt_ss(a); }
-VECMATH_FINLINE vec4f VECTORCALL v_sqrt_x(vec4f a) { return _mm_sqrt_ss(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4_fast(vec4f a) { return _mm_sqrt_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt4(vec4f a) { return _mm_sqrt_ps(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_fast_x(vec4f a) { return _mm_sqrt_ss(a); }
+VECTORCALL VECMATH_FINLINE vec4f v_sqrt_x(vec4f a) { return _mm_sqrt_ss(a); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_rot_1(vec4f a) { return V_SHUFFLE_REV(a, 0, 3, 2, 1); }
-VECMATH_FINLINE vec4f VECTORCALL v_rot_2(vec4f a) { return V_SHUFFLE_REV(a, 1, 0, 3, 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_rot_3(vec4f a) { return V_SHUFFLE_REV(a, 2, 1, 0, 3); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_1(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(0, 3, 2, 1)); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_2(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(1, 0, 3, 2)); }
-VECMATH_FINLINE vec4i VECTORCALL v_roti_3(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(2, 1, 0, 3)); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_1(vec4f a) { return V_SHUFFLE_REV(a, 0, 3, 2, 1); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_2(vec4f a) { return V_SHUFFLE_REV(a, 1, 0, 3, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_rot_3(vec4f a) { return V_SHUFFLE_REV(a, 2, 1, 0, 3); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_1(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(0, 3, 2, 1)); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_2(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(1, 0, 3, 2)); }
+VECTORCALL VECMATH_FINLINE vec4i v_roti_3(vec4i a) { return _mm_shuffle_epi32(a, _MM_SHUFFLE(2, 1, 0, 3)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxx(vec4f a) { return V_SHUFFLE_REV(a, 0,0,2,1); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxy(vec4f a) { return V_SHUFFLE_REV(a, 1,0,2,1); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yzxw(vec4f a) { return V_SHUFFLE_REV(a, 3,0,2,1); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxyw(vec4f a) { return V_SHUFFLE_REV(a, 3,1,0,2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xxyy(vec4f a) { return V_SHUFFLE_REV(a, 1,1,0,0); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zzww(vec4f a) { return V_SHUFFLE_REV(a, 3,3,2,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxx(vec4f a) { return V_SHUFFLE_REV(a, 0,0,2,1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxy(vec4f a) { return V_SHUFFLE_REV(a, 1,0,2,1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yzxw(vec4f a) { return V_SHUFFLE_REV(a, 3,0,2,1); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxyw(vec4f a) { return V_SHUFFLE_REV(a, 3,1,0,2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xxyy(vec4f a) { return V_SHUFFLE_REV(a, 1,1,0,0); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zzww(vec4f a) { return V_SHUFFLE_REV(a, 3,3,2,2); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzac(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(2,0,2,0)); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ywbd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,1,3,1)); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyab(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,0,1,0)); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zwcd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,3,2)); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bbyx(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(0,1,1,1)); }
-VECMATH_FINLINE vec4f VECTORCALL
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzac(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(2,0,2,0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ywbd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,1,3,1)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyab(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,0,1,0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zwcd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,3,2)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bbyx(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(0,1,1,1)); }
+VECTORCALL VECMATH_FINLINE vec4f
   v_perm_xaxa(vec4f xyzw, vec4f abcd) { return v_perm_yzxw(_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,0,0))); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yybb(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,1,1,1)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yybb(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,1,1,1)); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,1,0)); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_ayzw(vec4f xyzw, vec4f abcd) { return _mm_move_ss(xyzw, abcd); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycd(vec4f xyzw, vec4f abcd) { return _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3,2,1,0)); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_ayzw(vec4f xyzw, vec4f abcd) { return _mm_move_ss(xyzw, abcd); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzbx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzbx(vec4f xyzw, vec4f abcd)
 {
   vec4f bbxx =_mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(0,0,1,1));
   return _mm_shuffle_ps(xyzw, bbxx, _MM_SHUFFLE(2, 0, 2, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xzya(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xzya(vec4f xyzw, vec4f abcd)
 {
   vec4f yyaa =_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,1,1));
   return _mm_shuffle_ps(xyzw, yyaa, _MM_SHUFFLE(2, 0, 2, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yxxc(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yxxc(vec4f xyzw, vec4f abcd)
 {
   vec4f xxcc =_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(2,2,0,0));
   return _mm_shuffle_ps(xyzw, xxcc, _MM_SHUFFLE(2, 0, 0, 1));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_yaxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_yaxx(vec4f xyzw, vec4f abcd)
 {
   vec4f yyaa =_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,1,1));
   return _mm_shuffle_ps(yyaa, xyzw, _MM_SHUFFLE(0, 0, 2, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zxxb(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zxxb(vec4f xyzw, vec4f abcd)
 {
   vec4f xxbb =_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1,1,0,0));
   return _mm_shuffle_ps(xyzw, xxbb, _MM_SHUFFLE(2, 0, 0, 2));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_zayx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_zayx(vec4f xyzw, vec4f abcd)
 {
   vec4f zzaa =_mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(0,0,2,2));
   return _mm_shuffle_ps(zzaa, xyzw, _MM_SHUFFLE(0, 1, 2, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_bzxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_bzxx(vec4f xyzw, vec4f abcd)
 {
   vec4f bbzz =_mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(2,2,1,1));
   return _mm_shuffle_ps(bbzz, xyzw, _MM_SHUFFLE(0, 0, 2, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_caxx(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_caxx(vec4f xyzw, vec4f abcd)
 {
   return _mm_shuffle_ps(abcd, xyzw, _MM_SHUFFLE(0, 0, 0, 2));
 }
 
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzw(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 2); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycw(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 4); }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzd(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 8); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 2); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 4); }
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd) { return _mm_blend_ps(xyzw, abcd, 8); }
 
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xbzw(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xbzw(vec4f xyzw, vec4f abcd)
 {
   vec4f xxbb = _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(1, 1, 0, 0));
   return _mm_shuffle_ps(xxbb, xyzw, _MM_SHUFFLE(3, 2, 3, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xycw(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xycw(vec4f xyzw, vec4f abcd)
 {
   vec4f wwcc = _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(2, 2, 3, 3));
   return _mm_shuffle_ps(xyzw, wwcc, _MM_SHUFFLE(0, 3, 1, 0));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_perm_xyzd(vec4f xyzw, vec4f abcd)
+VECTORCALL VECMATH_FINLINE vec4f v_perm_xyzd(vec4f xyzw, vec4f abcd)
 {
   vec4f zzdd = _mm_shuffle_ps(xyzw, abcd, _MM_SHUFFLE(3, 3, 2, 2));
   return _mm_shuffle_ps(xyzw, zzdd, _MM_SHUFFLE(3, 0, 1, 0));
 }
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot2(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot2(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
   return _mm_add_ps(v_splat_x(m), v_splat_y(m));
 }
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot2_x(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot2_x(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
   return v_add_x(m, v_rot_1(m));
 }
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot3(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot3(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
 
@@ -704,7 +713,7 @@ VECMATH_FINLINE vec4f VECTORCALL sse2_dot3(vec4f a, vec4f b)
                _mm_shuffle_ps(m, m, _MM_SHUFFLE(0,0,2,1))
   );
 }
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot4(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot4(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
 
@@ -715,13 +724,13 @@ VECMATH_FINLINE vec4f VECTORCALL sse2_dot4(vec4f a, vec4f b)
                V_SHUFFLE_REV(m, 0,3,2,1))
   );
 }
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot3_x(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot3_x(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
 
   return _mm_add_ss(_mm_add_ss(m, v_splat_y(m)), _mm_shuffle_ps(m, m, 2));
 }
-VECMATH_FINLINE vec4f VECTORCALL sse2_dot4_x(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse2_dot4_x(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
 
@@ -729,81 +738,81 @@ VECMATH_FINLINE vec4f VECTORCALL sse2_dot4_x(vec4f a, vec4f b)
                     _mm_add_ss(_mm_shuffle_ps(m, m, 2), v_splat_w(m)));
 }
 
-VECMATH_FINLINE vec4f VECTORCALL sse2_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
+VECTORCALL VECMATH_FINLINE vec4f sse2_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
 
 #if _TARGET_SIMD_SSE >= 4 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE4_1__)
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot4(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0xFF); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot4_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0xF1); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot3(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0x7F); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot3_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0x71); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot2(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x3F); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot2_x(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x31); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse4_dot3_x(a,b), v_splat_w(a)); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0xFF); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0xF1); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3(vec4f a, vec4f b) { return _mm_dp_ps(a,b, 0x7F); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3_x(vec4f a, vec4f b) { return _mm_dp_ps(a,b,0x71); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x3F); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2_x(vec4f a, vec4f b) { return _mm_dp_ps(a, b, 0x31); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse4_dot3_x(a,b), v_splat_w(a)); }
 #else // fallback to SSE2
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot4_x(vec4f a, vec4f b) { return sse2_dot4_x(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot3(vec4f a, vec4f b) { return sse2_dot3(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot2(vec4f a, vec4f b) { return sse2_dot2(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse4_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot4_x(vec4f a, vec4f b) { return sse2_dot4_x(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3(vec4f a, vec4f b) { return sse2_dot3(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2(vec4f a, vec4f b) { return sse2_dot2(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse4_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
 #endif
 
 #if _TARGET_SIMD_SSE >= 3 || defined(_DAGOR_PROJECT_OPTIONAL_SSE4) || defined(__SSE3__)
-VECMATH_FINLINE vec4f VECTORCALL sse3_dot4(vec4f a, vec4f b)
+VECTORCALL VECMATH_FINLINE vec4f sse3_dot4(vec4f a, vec4f b)
 {
   vec4f m = _mm_mul_ps(a, b);
   m = _mm_hadd_ps(m,m);
   return _mm_hadd_ps(m,m);
 }
-VECMATH_FINLINE vec4f VECTORCALL sse3_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
+VECTORCALL VECMATH_FINLINE vec4f sse3_plane_dist_x(plane3f a, vec3f b) { return v_add_x(sse2_dot3_x(a,b), v_splat_w(a)); }
 #else
-VECMATH_FINLINE vec4f VECTORCALL sse3_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
-VECMATH_FINLINE vec4f VECTORCALL sse3_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f sse3_dot4(vec4f a, vec4f b) { return sse2_dot4(a, b); }
+VECTORCALL VECMATH_FINLINE vec4f sse3_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
 #endif
 
 
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE vec4f VECTORCALL v_dot4(vec4f a, vec4f b) { return sse4_dot4(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot4_x(vec4f a, vec4f b) { return sse4_dot4_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3(vec4f a, vec4f b) { return sse4_dot3(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3_x(vec4f a, vec4f b) { return sse4_dot3_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2(vec4f a, vec4f b) { return sse4_dot2(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2_x(vec4f a, vec4f b) { return sse4_dot2_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist_x(plane3f a, vec3f b) { return sse4_plane_dist_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return sse4_dot4(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return sse4_dot4_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return sse4_dot3(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b) { return sse4_dot3_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b) { return sse4_dot2(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse4_dot2_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse4_plane_dist_x(a,b); }
 #elif _TARGET_SIMD_SSE >= 3
-VECMATH_FINLINE vec4f VECTORCALL v_dot4(vec4f a, vec4f b) { return sse3_dot4(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot4_x(vec4f a, vec4f b) { return sse3_dot4(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3(vec4f a, vec4f b) { return sse2_dot3(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2(vec4f a, vec4f b) { return sse2_dot2(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist_x(plane3f a, vec3f b) { return sse3_plane_dist_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return sse3_dot4(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return sse3_dot4(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return sse2_dot3(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b) { return sse2_dot2(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse3_plane_dist_x(a,b); }
 #else
-VECMATH_FINLINE vec4f VECTORCALL v_dot4(vec4f a, vec4f b) { return sse2_dot4(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot4_x(vec4f a, vec4f b) { return sse2_dot4_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3(vec4f a, vec4f b) { return sse2_dot3(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2(vec4f a, vec4f b) { return sse2_dot2(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a,b); }
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4(vec4f a, vec4f b) { return sse2_dot4(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot4_x(vec4f a, vec4f b) { return sse2_dot4_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3(vec4f a, vec4f b) { return sse2_dot3(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot3_x(vec4f a, vec4f b) { return sse2_dot3_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2(vec4f a, vec4f b) { return sse2_dot2(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_dot2_x(vec4f a, vec4f b) { return sse2_dot2_x(a,b); }
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist_x(plane3f a, vec3f b) { return sse2_plane_dist_x(a,b); }
 #endif
 
-VECMATH_FINLINE vec4f VECTORCALL v_norm4(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot4_x(a,a)))); }
-VECMATH_FINLINE vec4f VECTORCALL v_norm3(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot3_x(a,a)))); }
-VECMATH_FINLINE vec4f VECTORCALL v_norm2(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot2_x(a,a)))); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm4(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot4_x(a,a)))); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm3(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot3_x(a,a)))); }
+VECTORCALL VECMATH_FINLINE vec4f v_norm2(vec4f a) { return v_div(a, v_splat_x(v_sqrt_x(v_dot2_x(a,a)))); }
 
-VECMATH_FINLINE vec4f VECTORCALL v_plane_dist(plane3f a, vec3f b)
+VECTORCALL VECMATH_FINLINE vec4f v_plane_dist(plane3f a, vec3f b)
 {
   return v_splat_x(v_plane_dist_x(a, b));
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43ca(mat44f& tm, const float *const __restrict m43)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43ca(mat44f& tm, const float *const __restrict m43)
 {
   v_mat44_make_from_43cu(tm, m43);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f& tm, const float *const __restrict m43)
+VECTORCALL VECMATH_FINLINE void v_mat44_make_from_43cu(mat44f& tm, const float *const __restrict m43)
 {
   vec4f v0 = v_ldu(m43 + 0);
   vec4f v1 = v_ldu(m43 + 4);
@@ -822,12 +831,12 @@ VECMATH_FINLINE void VECTORCALL v_mat44_make_from_43cu(mat44f& tm, const float *
 #endif // _TARGET_SIMD_SSE >= 4
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat_43ca_from_mat44(float * __restrict m43, const mat44f& tm)
+VECTORCALL VECMATH_FINLINE void v_mat_43ca_from_mat44(float * __restrict m43, const mat44f& tm)
 {
   v_mat_43cu_from_mat44(m43, tm);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, const mat44f& tm)
+VECTORCALL VECMATH_FINLINE void v_mat_43cu_from_mat44(float * __restrict m43, const mat44f& tm)
 {
 #if _TARGET_SIMD_SSE >= 4
   vec4f v0 = _mm_insert_ps(tm.col0, tm.col1, _MM_MK_INSERTPS_NDX(0, 3, 0));
@@ -843,33 +852,33 @@ VECMATH_FINLINE void VECTORCALL v_mat_43cu_from_mat44(float * __restrict m43, co
   v_stu(m43 + 8, v2);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_ident(mat44f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat44_ident(mat44f &dest)
 {
   dest.col0 = V_C_UNIT_1000;
   dest.col1 = V_C_UNIT_0100;
   dest.col2 = V_C_UNIT_0010;
   dest.col3 = V_C_UNIT_0001;
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_ident_swapxz(mat44f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat44_ident_swapxz(mat44f &dest)
 {
   dest.col0 = V_C_UNIT_0010;
   dest.col1 = V_C_UNIT_0100;
   dest.col2 = V_C_UNIT_1000;
   dest.col3 = V_C_UNIT_0001;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_ident(mat33f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat33_ident(mat33f &dest)
 {
   dest.col0 = V_C_UNIT_1000;
   dest.col1 = V_C_UNIT_0100;
   dest.col2 = V_C_UNIT_0010;
 }
-VECMATH_FINLINE void VECTORCALL v_mat33_ident_swapxz(mat33f &dest)
+VECTORCALL VECMATH_FINLINE void v_mat33_ident_swapxz(mat33f &dest)
 {
   dest.col0 = V_C_UNIT_0010;
   dest.col1 = V_C_UNIT_0100;
   dest.col2 = V_C_UNIT_1000;
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(mat44f &dest, mat44f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(mat44f &dest, mat44f_cref src)
 {
   __m128 tmp3, tmp2, tmp1, tmp0;
 
@@ -884,12 +893,12 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose(mat44f &dest, mat44f_cref src)
   dest.col3 = _mm_shuffle_ps(tmp2, tmp3, 0xDD);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose(vec4f &r0, vec4f &r1, vec4f &r2, vec4f &r3)
 {
    _MM_TRANSPOSE4_PS(r0, r1, r2, r3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, vec3f col0, vec3f col1, vec3f col2)
+VECTORCALL VECMATH_FINLINE void v_mat33_transpose(mat33f &dest, vec3f col0, vec3f col1, vec3f col2)
 {
   __m128 tmp3, tmp2, tmp1, tmp0;
 
@@ -903,7 +912,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_transpose(mat33f &dest, vec3f col0, vec3
   dest.col2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, const vec4f& col3)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat33(mat33f &dest, vec3f col0, vec3f col1, vec3f col2, const vec4f& col3)
 {
   __m128 tmp3, tmp2, tmp1, tmp0;
 
@@ -917,7 +926,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat33(mat33f &dest, vec3f c
   dest.col2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat43_transpose_to_mat44(mat44f &dest, mat43f_cref src)
 {
   __m128 tmp3, tmp2, tmp1, tmp0;
 
@@ -931,7 +940,7 @@ VECMATH_FINLINE void VECTORCALL v_mat43_transpose_to_mat44(mat44f &dest, mat43f_
   dest.col2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
   dest.col3 = _mm_shuffle_ps(tmp2, tmp3, 0xDD);
 }
-VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
+VECTORCALL VECMATH_FINLINE void v_mat44_transpose_to_mat43(mat43f &dest, mat44f_cref src)
 {
   __m128 tmp3, tmp2, tmp1, tmp0;
 
@@ -945,7 +954,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_transpose_to_mat43(mat43f &dest, mat44f_
   dest.row2 = _mm_shuffle_ps(tmp2, tmp3, 0x88);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec4(mat44f_cref m, vec4f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec4(mat44f_cref m, vec4f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
@@ -957,7 +966,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec4(mat44f_cref m, vec4f v)
     _mm_add_ps(_mm_mul_ps(zzzz, m.col2), _mm_mul_ps(wwww, m.col3))
   );
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
@@ -966,7 +975,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3v(mat44f_cref m, vec3f v)
   return _mm_add_ps(_mm_add_ps(_mm_mul_ps(xxxx, m.col0), _mm_mul_ps(yyyy, m.col1)),
                     _mm_mul_ps(zzzz, m.col2));
 }
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
@@ -978,7 +987,7 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_mul_vec3p(mat44f_cref m, vec3f v)
   );
 }
 
-VECMATH_FINLINE vec3f VECTORCALL v_mat33_mul_vec3(mat33f_cref m, vec3f v)
+VECTORCALL VECMATH_FINLINE vec3f v_mat33_mul_vec3(mat33f_cref m, vec3f v)
 {
   vec4f xxxx = v_splat_x(v);
   vec4f yyyy = _mm_shuffle_ps(v, v, _MM_SHUFFLE(1,1,1,1));
@@ -988,7 +997,7 @@ VECMATH_FINLINE vec3f VECTORCALL v_mat33_mul_vec3(mat33f_cref m, vec3f v)
                     _mm_mul_ps(zzzz, m.col2));
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat44_inverse(mat44f &dest, mat44f_cref m)
 {
   __m128 minor0, minor1, minor2, minor3;
   __m128 row0, row1, row2, row3;
@@ -1059,7 +1068,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
   det = _mm_mul_ps(row0, minor0);
   det = _mm_add_ps(V_SHUFFLE(det, 0x4E), det);
   det = _mm_add_ss(V_SHUFFLE(det, 0xB1), det);
-  tmp1 = _mm_rcp_ss(det);
+  tmp1 = v_rcp_safe(det);
   det = _mm_sub_ss(_mm_add_ss(tmp1, tmp1), _mm_mul_ss(det, _mm_mul_ss(tmp1, tmp1)));
   det = v_splat_x(det);
   dest.col0 = _mm_mul_ps(det, minor0);
@@ -1068,7 +1077,7 @@ VECMATH_FINLINE void VECTORCALL v_mat44_inverse(mat44f &dest, mat44f_cref m)
   dest.col3 = _mm_mul_ps(det, minor3);
 }
 
-VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m)
+VECTORCALL VECMATH_FINLINE void v_mat33_inverse(mat33f &dest, mat33f_cref m)
 {
   vec4f tmp0, tmp1, tmp2, tmp3, tmp4, dot, invdet, inv0, inv1, inv2;
 
@@ -1076,7 +1085,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m)
   tmp0 = v_cross3(m.col1, m.col2);
   tmp1 = v_cross3(m.col2, m.col0);
   dot = v_dot3(tmp2, m.col2);
-  invdet = v_rcp(dot);
+  invdet = v_rcp_safe(dot);
 
   tmp3 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(0,2,0,2));
   tmp4 = _mm_shuffle_ps(tmp0, tmp1, _MM_SHUFFLE(1,3,1,3));
@@ -1089,7 +1098,7 @@ VECMATH_FINLINE void VECTORCALL v_mat33_inverse(mat33f &dest, mat33f_cref m)
   dest.col2 = _mm_mul_ps(inv2, invdet);
 }
 
-VECMATH_FINLINE vec4f VECTORCALL v_mat44_det(mat44f_cref m)
+VECTORCALL VECMATH_FINLINE vec4f v_mat44_det(mat44f_cref m)
 {
   __m128 minor0;
   __m128 row0, row1, row2, row3;
@@ -1131,29 +1140,29 @@ VECMATH_FINLINE vec4f VECTORCALL v_mat44_det(mat44f_cref m)
 
 #if defined(_MSC_VER) && (_MSC_VER < 1600 || (_MSC_VER < 1700 && _TARGET_64BIT)) && !defined(__clang__)
 //due to compiler bug (vc2008-32 and vc2010-64)
-VECMATH_FINLINE float VECTORCALL v_extract_x(vec4f v) { return v.m128_f32[0]; }
-VECMATH_FINLINE float VECTORCALL v_extract_y(vec4f v) { return v.m128_f32[1]; }
-VECMATH_FINLINE float VECTORCALL v_extract_z(vec4f v) { return v.m128_f32[2]; }
-VECMATH_FINLINE float VECTORCALL v_extract_w(vec4f v) { return v.m128_f32[3]; }
+VECTORCALL VECMATH_FINLINE float v_extract_x(vec4f v) { return v.m128_f32[0]; }
+VECTORCALL VECMATH_FINLINE float v_extract_y(vec4f v) { return v.m128_f32[1]; }
+VECTORCALL VECMATH_FINLINE float v_extract_z(vec4f v) { return v.m128_f32[2]; }
+VECTORCALL VECMATH_FINLINE float v_extract_w(vec4f v) { return v.m128_f32[3]; }
 #else
-VECMATH_FINLINE float VECTORCALL v_extract_x( vec4f a ) { return _mm_cvtss_f32(a); }
-VECMATH_FINLINE float VECTORCALL v_extract_y( vec4f a ) { return _mm_cvtss_f32(v_splat_y(a)); }
-VECMATH_FINLINE float VECTORCALL v_extract_z( vec4f a ) { return _mm_cvtss_f32(v_splat_z(a)); }
-VECMATH_FINLINE float VECTORCALL v_extract_w( vec4f a ) { return _mm_cvtss_f32(v_splat_w(a)); }
+VECTORCALL VECMATH_FINLINE float v_extract_x( vec4f a ) { return _mm_cvtss_f32(a); }
+VECTORCALL VECMATH_FINLINE float v_extract_y( vec4f a ) { return _mm_cvtss_f32(v_splat_y(a)); }
+VECTORCALL VECMATH_FINLINE float v_extract_z( vec4f a ) { return _mm_cvtss_f32(v_splat_z(a)); }
+VECTORCALL VECMATH_FINLINE float v_extract_w( vec4f a ) { return _mm_cvtss_f32(v_splat_w(a)); }
 #endif
 
-VECMATH_FINLINE int VECTORCALL v_extract_xi(vec4i v) {return _mm_cvtsi128_si32(v);}
+VECTORCALL VECMATH_FINLINE int v_extract_xi(vec4i v) {return _mm_cvtsi128_si32(v);}
 #if _TARGET_SIMD_SSE >= 4
-VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v) {return _mm_extract_epi32(v, 1);}
-VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v) {return _mm_extract_epi32(v, 2);}
-VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v) {return _mm_extract_epi32(v, 3);}
-VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i v) {return _mm_extract_epi64(v, 0);}
-VECMATH_FINLINE int64_t VECTORCALL v_extract_yi64(vec4i v) {return _mm_extract_epi64(v, 1);}
+VECTORCALL VECMATH_FINLINE int v_extract_yi(vec4i v) {return _mm_extract_epi32(v, 1);}
+VECTORCALL VECMATH_FINLINE int v_extract_zi(vec4i v) {return _mm_extract_epi32(v, 2);}
+VECTORCALL VECMATH_FINLINE int v_extract_wi(vec4i v) {return _mm_extract_epi32(v, 3);}
+VECTORCALL VECMATH_FINLINE int64_t v_extract_xi64(vec4i v) {return _mm_extract_epi64(v, 0);}
+VECTORCALL VECMATH_FINLINE int64_t v_extract_yi64(vec4i v) {return _mm_extract_epi64(v, 1);}
 #else
-VECMATH_FINLINE int VECTORCALL v_extract_yi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(1,1,1,1)));}
-VECMATH_FINLINE int VECTORCALL v_extract_zi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(2,2,2,2)));}
-VECMATH_FINLINE int VECTORCALL v_extract_wi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(3,3,3,3)));}
-VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i a)
+VECTORCALL VECMATH_FINLINE int v_extract_yi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(1,1,1,1)));}
+VECTORCALL VECMATH_FINLINE int v_extract_zi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(2,2,2,2)));}
+VECTORCALL VECMATH_FINLINE int v_extract_wi(vec4i v) {return _mm_cvtsi128_si32(_mm_shuffle_epi32(v, _MM_SHUFFLE(3,3,3,3)));}
+VECTORCALL VECMATH_FINLINE int64_t v_extract_xi64(vec4i a)
 {
 #if defined(_MSC_VER) && !defined(__clang__)//visual studio is not capable of produce reasonable code otherwise!
     return a.m128i_i64[0];
@@ -1161,7 +1170,7 @@ VECMATH_FINLINE int64_t VECTORCALL v_extract_xi64(vec4i a)
     int64_t t; _mm_storel_epi64((__m128i*)&t, a); return t;
 #endif
 }
-VECMATH_FINLINE int64_t VECTORCALL v_extract_yi64(vec4i a)
+VECTORCALL VECMATH_FINLINE int64_t v_extract_yi64(vec4i a)
 {
 #if defined(_MSC_VER) && !defined(__clang__)
   return a.m128i_i64[1];
@@ -1171,28 +1180,28 @@ VECMATH_FINLINE int64_t VECTORCALL v_extract_yi64(vec4i a)
 }
 #endif
 
-VECMATH_FINLINE vec4i VECTORCALL v_splatsi64(int64_t a) { return _mm_set1_epi64x(a); }
+VECTORCALL VECMATH_FINLINE vec4i v_splatsi64(int64_t a) { return _mm_set1_epi64x(a); }
 
-VECMATH_FINLINE short VECTORCALL v_extract_xi16(vec4i v) {return (short)_mm_extract_epi16(v, 0);}
+VECTORCALL VECMATH_FINLINE short v_extract_xi16(vec4i v) {return (short)_mm_extract_epi16(v, 0);}
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi(vec3f v, vec3f a)
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi(vec3f v, vec3f a)
 {
   vec4i eq = _mm_cmpeq_epi32(v_cast_vec4i(v),v_cast_vec4i(a));
   return v_extract_xi(eq) ? 1 : 0;
 }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eqi_0(vec3f v) { return v_extract_xi(v_cast_vec4i(v)) == 0 ? 1 : 0; }
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq(vec3f v, vec3f a) { return _mm_comieq_ss(v,a); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt(vec3f v, vec3f a) { return _mm_comigt_ss(v,a); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge(vec3f v, vec3f a) { return _mm_comige_ss(v,a); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt(vec3f v, vec3f a) { return _mm_comilt_ss(v,a); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le(vec3f v, vec3f a) { return _mm_comile_ss(v,a); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq(vec3f v, vec3f a) { return _mm_comieq_ss(v,a); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt(vec3f v, vec3f a) { return _mm_comigt_ss(v,a); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge(vec3f v, vec3f a) { return _mm_comige_ss(v,a); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt(vec3f v, vec3f a) { return _mm_comilt_ss(v,a); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le(vec3f v, vec3f a) { return _mm_comile_ss(v,a); }
 
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_eq_0(vec3f v) { return v_test_vec_x_eq(v, v_zero()); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_gt_0(vec3f v) { return v_test_vec_x_gt(v, v_zero()); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_ge_0(vec3f v) { return v_test_vec_x_ge(v, v_zero()); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_lt_0(vec3f v) { return v_test_vec_x_lt(v, v_zero()); }
-VECMATH_FINLINE int VECTORCALL v_test_vec_x_le_0(vec3f v) { return v_test_vec_x_le(v, v_zero()); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_eq_0(vec3f v) { return v_test_vec_x_eq(v, v_zero()); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_gt_0(vec3f v) { return v_test_vec_x_gt(v, v_zero()); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_ge_0(vec3f v) { return v_test_vec_x_ge(v, v_zero()); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_lt_0(vec3f v) { return v_test_vec_x_lt(v, v_zero()); }
+VECTORCALL VECMATH_FINLINE int v_test_vec_x_le_0(vec3f v) { return v_test_vec_x_le(v, v_zero()); }
 
 #undef V_SHUFFLE
 #undef  V_SHUFFLE_REV


### PR DESCRIPTION
Added v_is_unsafe_divisor, v_quat_slerp
Fixed compilation on MacOSX
Safer bad matrix decompose, inverse
Fixed and refactored to single implementation v_quat_from_mat Tested and refactored quat functions